### PR TITLE
ci(release): keep the `release` auto-update channel fresh on every release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,21 @@ jobs:
             build/update.json
           generate_release_notes: true
 
-      - name: Update release tag for auto-updates
+      - name: Refresh the auto-update channel
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
+          # Move the floating `release` tag to this commit.
           git tag -f release
           git push -f origin release
+          # Zotero auto-update reads the manifest's update_url, which points at
+          # releases/download/release/update.json. That path only resolves if a
+          # GitHub Release named `release` exists with update.json attached —
+          # moving the tag alone is NOT enough. Ensure the release exists, then
+          # overwrite its update.json so the updater always sees the latest XPI.
+          gh release view release >/dev/null 2>&1 || \
+            gh release create release \
+              --title "Auto-update channel" \
+              --latest=false \
+              --notes "Serves update.json for Zotero's built-in auto-updater. Do not download from here manually — install Citegeist from the latest versioned release."
+          gh release upload release build/update.json --clobber


### PR DESCRIPTION
## Problem

Zotero's auto-updater reads the plugin manifest's `update_url`, which points at:

```
releases/download/release/update.json
```

That path only resolves if a GitHub **Release** named `release` exists with `update.json` attached. The release workflow only ran `git tag -f release` (moves the *tag*), which neither creates nor refreshes that Release. As a result there was **no `release` Release at all** — the URL 404'd, so no installed copy could ever discover a new version via auto-update.

Found while shipping v2.0.0. I repaired the channel by hand (created the `release` Release with v2.0.0's `update.json`, hash-verified against the published XPI), so **2.0.0 auto-update works now**. This PR prevents the gap from recurring on future releases.

## Change

The final workflow step now:
1. Moves the `release` tag (as before).
2. Creates the `release` Release if it doesn't exist.
3. `gh release upload release build/update.json --clobber` — overwrites `update.json` so the updater always sees the current XPI.

Uses the built-in `GITHUB_TOKEN` (workflow already has `contents: write`).

## Verification

- Does not affect the already-published v2.0.0 release.
- Will be exercised on the next tagged release; the `gh release view || gh release create` guard makes it idempotent whether or not the `release` Release already exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)