### PR TITLE
feat(network): citation browser redesign — source context, sort modes, hide-in-library

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -131,25 +131,13 @@ If you'd like to help translate Citegeist into your language, please comment wit
 
 ---
 
-## Citation network browser redesign — toolbar, sorting, and in-library filtering
+## Server-side sort for the citation network browser
 
-**Labels:** `enhancement`, `design`
+**Labels:** `enhancement`, `performance`
 
-A planned redesign of the citation network browser's header and result controls. A UX mockup exists at [`mockups/citation-network-toolbar-ux.html`](mockups/citation-network-toolbar-ux.html) — open it in a browser to see the intended layout.
+The citation network browser now sorts the **loaded page** of results client-side (`compareNetworkWorks` / `getVisibleNetworkWorks` in `src/modules/citationNetwork/results.ts`). For paginated result sets, sorting the whole set would require asking OpenAlex to sort server-side via its `sort=` parameter (e.g. `cited_by_count:desc`, `fwci:desc`, `publication_date:asc`) and re-fetching on sort change. Local-only modes (first-author surname, "not in my library first") stay client-side.
 
-**Scope:**
-
-- **Redesigned dialog header** — a compact command bar showing the source paper's own metadata (authors · venue · year) and citation count alongside the title, instead of just the title.
-- **Richer sorting** — beyond the current citation-count / year / title options, add:
-  - FWCI (field-normalized impact) — the data is already in each work's OpenAlex response; field-normalized metrics are more meaningful than raw counts, so this aligns with Citegeist's core value
-  - Percentile
-  - First-author surname (with multi-word surname-prefix handling: "de la Cruz", "van der Berg")
-  - "Not in my library first" — surface works you haven't added yet
-  - Server-side sorting via OpenAlex `sort=` params where supported, local sorting otherwise
-- **Hide-in-library filter** — optionally drop works already in your library (by DOI or added-this-session ID) so the list shows only new discoveries.
-- Unknown publication dates sort last regardless of direction.
-
-**Note for implementers:** a previous session drafted vitest specs for the pure pieces of this (a sort comparator, an OpenAlex-sort mapping, an in-library visibility filter, and a `getItemSourceMetaLine` header formatter). They were removed from the 2.0 release to keep scope tight, but the contracts are a good starting point — extract the sort/filter logic currently inline in `src/modules/citationNetwork/results.ts` into pure, testable functions, add a `getItemSourceMetaLine(item)` helper in `dialog.ts`, and preserve every selector `bindDialogEvents` depends on when reworking the header.
+This is a refinement of the now-shipped redesign (header with source metadata + cited-by stat, new sort modes, hide-in-library filter — see the [toolbar mockup](mockups/citation-network-toolbar-ux.html)). It mainly matters for source papers with hundreds of citing works, where the most-cited result may sit beyond the first loaded page.
 
 ---
 

--- a/src/modules/citationNetwork/dialog.ts
+++ b/src/modules/citationNetwork/dialog.ts
@@ -17,7 +17,7 @@
 import { getWorkByDOI } from "../openalex";
 import { escapeHTML, safeInnerHTML, OpenAlexNetworkError, logError } from "../utils";
 import { SEARCH_DEBOUNCE_MS, INFINITE_SCROLL_THRESHOLD_PX } from "../../constants";
-import type { NetworkMode, NetworkState } from "./types";
+import type { NetworkMode, NetworkSortKey, NetworkState } from "./types";
 import { getDialogCSS } from "./styles";
 import { loadResults, renderResults, toggleExpanded } from "./results";
 import { handleAdd, handleUndo, getExistingDOIs } from "./actions";
@@ -129,7 +129,7 @@ export async function showCitationNetwork(
   `;
 
   const title = item.getField("title");
-  safeInnerHTML(dialog, buildDialogHTML(title));
+  safeInnerHTML(dialog, buildDialogHTML(title, getItemSourceMetaLine(item)));
 
   const styleEl = doc.createElementNS("http://www.w3.org/1999/xhtml", "style");
   styleEl.textContent = getDialogCSS();
@@ -261,6 +261,7 @@ export async function showCitationNetwork(
     hasMore: true,
     loading: false,
     sortBy: "citations",
+    hideInLibrary: false,
     existingDOIs,
     generation: 0,
     searchTimeout: null,
@@ -282,6 +283,12 @@ export async function showCitationNetwork(
 
   bindDialogEvents(state);
   updateDefaultCollectionLabel(state);
+
+  // Fill the source paper's own cited-by count in the header now that the
+  // OpenAlex work is loaded.
+  const citedStat = dialog.querySelector("#cg-source-cited-count .cg-stat-value");
+  if (citedStat) citedStat.textContent = (work.cited_by_count ?? 0).toLocaleString();
+
   await loadResults(state);
 
   const searchInput = dialog.querySelector(".cg-search-input") as HTMLInputElement;
@@ -292,40 +299,108 @@ export async function showCitationNetwork(
 // Dialog HTML shell
 // ────────────────────────────────────────────────────────
 
-export function buildDialogHTML(title: string): string {
+/**
+ * One-line source metadata for the dialog header: `Surname, Surname & Surname \u00B7
+ * Venue \u00B7 Year`. Authors use last names only; more than three collapse to
+ * "Surname et al.". Any missing part is dropped; returns "" when nothing is
+ * available. Filters to authors when Zotero can resolve the creator type \u2014
+ * the network browser is DOI-gated, so editors essentially never appear here.
+ */
+export function getItemSourceMetaLine(item: _ZoteroTypes.Item): string {
+  const parts: string[] = [];
+
+  let authorTypeID: number | undefined;
+  try {
+    const creatorTypes = (Zotero as { CreatorTypes?: { getID?: (name: string) => number } })
+      .CreatorTypes;
+    authorTypeID = creatorTypes?.getID?.("author");
+  } catch {
+    authorTypeID = undefined;
+  }
+  const creators = (item.getCreators?.() ?? []) as Array<{
+    creatorTypeID?: number;
+    lastName?: string;
+    name?: string;
+  }>;
+  const surnames = creators
+    .filter(
+      (c) => authorTypeID == null || c.creatorTypeID == null || c.creatorTypeID === authorTypeID,
+    )
+    .map((c) => (c.lastName || c.name || "").trim())
+    .filter(Boolean);
+
+  if (surnames.length === 1) {
+    parts.push(surnames[0]);
+  } else if (surnames.length === 2) {
+    parts.push(`${surnames[0]} & ${surnames[1]}`);
+  } else if (surnames.length === 3) {
+    parts.push(`${surnames[0]}, ${surnames[1]} & ${surnames[2]}`);
+  } else if (surnames.length > 3) {
+    parts.push(`${surnames[0]} et al.`);
+  }
+
+  const venue = (item.getField?.("publicationTitle") || "").trim();
+  if (venue) parts.push(venue);
+
+  const yearMatch = (item.getField?.("date") || "").match(/\d{4}/);
+  if (yearMatch) parts.push(yearMatch[0]);
+
+  return parts.join(" \u00B7 ");
+}
+
+export function buildDialogHTML(title: string, sourceMetaLine: string): string {
+  const sourceMeta = sourceMetaLine
+    ? `<div class="cg-source-authors" id="cg-source-meta">${escapeHTML(sourceMetaLine)}</div>`
+    : "";
   return `
-    <div class="cg-dialog-header">
+    <div class="cg-dialog-chrome">
       <button class="cg-close-btn" id="cg-btn-close" title="Close"
               aria-label="Close citation network browser">\u00D7</button>
+    </div>
+    <div class="cg-dialog-top">
       <div class="cg-header-text">
-        <div class="cg-dialog-title">Citation Network</div>
-        <div class="cg-dialog-subtitle">${escapeHTML(title)}</div>
+        <div class="cg-dialog-eyebrow">Citation Network</div>
+        <div class="cg-dialog-title" title="${escapeHTML(title)}">${escapeHTML(title)}</div>
+        ${sourceMeta}
+      </div>
+      <div class="cg-count-stack">
+        <div class="cg-stat" id="cg-source-cited-count">
+          <strong class="cg-stat-value">\u2026</strong>
+          <span class="cg-stat-label">Cited by</span>
+        </div>
       </div>
     </div>
-    <div class="cg-dialog-tabs" role="tablist" aria-label="Citation direction">
-      <div class="cg-tabs-inner">
+    <div class="cg-command-bar">
+      <div class="cg-tabs-inner" role="tablist" aria-label="Citation direction">
         <button class="cg-tab" data-mode="citing" role="tab" id="cg-tab-citing"
-                aria-selected="false" aria-controls="cg-dialog-body"
-                tabindex="-1">Cited By</button>
+                aria-selected="false" aria-controls="cg-dialog-body" tabindex="-1">Cited By</button>
         <button class="cg-tab" data-mode="references" role="tab" id="cg-tab-references"
-                aria-selected="false" aria-controls="cg-dialog-body"
-                tabindex="-1">References</button>
+                aria-selected="false" aria-controls="cg-dialog-body" tabindex="-1">References</button>
       </div>
-    </div>
-    <div class="cg-dialog-toolbar">
       <div class="cg-search-wrap">
-        <span class="cg-search-icon">\uD83D\uDD0D</span>
+        <span class="cg-search-icon" aria-hidden="true">\uD83D\uDD0D</span>
         <input type="text" class="cg-search-input"
                placeholder="Search titles, authors\u2026"
                aria-label="Filter results by title or author" />
       </div>
-      <select class="cg-sort-select" aria-label="Sort results by">
-        <option value="citations">Most cited</option>
-        <option value="fwci-desc">Highest FWCI</option>
-        <option value="percentile-desc">Top percentile</option>
-        <option value="year-desc">Newest</option>
-        <option value="year-asc">Oldest</option>
-      </select>
+      <div class="cg-control-cluster">
+        <button type="button" class="cg-hide-in-library" id="cg-hide-in-library"
+                role="switch" aria-checked="false"
+                aria-label="Hide works already in your library">
+          <span class="cg-switch" aria-hidden="true"></span>Hide in library
+        </button>
+        <label class="cg-sort-label">Sort:
+          <select class="cg-sort-select" aria-label="Sort results by">
+            <option value="citations">Most cited</option>
+            <option value="fwci-desc">Highest FWCI</option>
+            <option value="percentile-desc">Top percentile</option>
+            <option value="year-desc">Newest</option>
+            <option value="year-asc">Oldest</option>
+            <option value="author-asc">First author</option>
+            <option value="not-in-library">Not in library first</option>
+          </select>
+        </label>
+      </div>
     </div>
     <div class="cg-dialog-body" id="cg-dialog-body" role="tabpanel"
          aria-labelledby="cg-tab-citing" aria-live="polite" aria-busy="true">
@@ -474,7 +549,16 @@ export function bindDialogEvents(state: NetworkState): void {
   // Sort
   const sortSelect = dialog.querySelector(".cg-sort-select") as HTMLSelectElement;
   sortSelect?.addEventListener("change", () => {
-    state.sortBy = sortSelect.value;
+    state.sortBy = sortSelect.value as NetworkSortKey;
+    renderResults(state, searchInput?.value || "");
+  });
+
+  // Hide-in-library filter toggle
+  const hideToggle = dialog.querySelector("#cg-hide-in-library") as HTMLButtonElement | null;
+  hideToggle?.addEventListener("click", () => {
+    state.hideInLibrary = !state.hideInLibrary;
+    hideToggle.setAttribute("aria-checked", state.hideInLibrary ? "true" : "false");
+    hideToggle.classList.toggle("cg-switch-on", state.hideInLibrary);
     renderResults(state, searchInput?.value || "");
   });
 

--- a/src/modules/citationNetwork/results.ts
+++ b/src/modules/citationNetwork/results.ts
@@ -12,7 +12,12 @@ import {
   type OpenAlexWork,
 } from "../openalex";
 import { escapeHTML, safeInnerHTML, OpenAlexNetworkError, logError } from "../utils";
-import { MAX_RENDERED_RESULTS, type NetworkState } from "./types";
+import {
+  MAX_RENDERED_RESULTS,
+  SURNAME_PREFIXES,
+  type NetworkSortKey,
+  type NetworkState,
+} from "./types";
 import { getDefaultCollectionName } from "./actions";
 import { DEFAULT_NETWORK_PAGE_SIZE, PREF_NETWORK_PAGE_SIZE } from "../../constants";
 
@@ -92,44 +97,159 @@ export async function loadResults(state: NetworkState, append = false): Promise<
   state.dialog.classList.remove("cg-is-loading");
 }
 
+// ────────────────────────────────────────────────────────
+// Sorting & filtering (pure — unit-tested)
+// ────────────────────────────────────────────────────────
+
+/** Short OpenAlex work id, e.g. `W123`, stripped of the URL prefix. */
+function shortWorkId(work: OpenAlexWork): string {
+  return work.id.replace("https://openalex.org/", "");
+}
+
+/** Clean, lowercased DOI (no `https://doi.org/` prefix), or null. */
+function cleanDoi(work: OpenAlexWork): string | null {
+  return work.doi ? work.doi.replace("https://doi.org/", "").toLowerCase() : null;
+}
+
+/**
+ * Is this work already in the user's library? True when its DOI is in
+ * `existingDOIs` OR it was added during this session. Mirrors the per-row
+ * "In Library" badge logic in {@link renderResults}.
+ */
+export function isWorkInLibrary(
+  work: OpenAlexWork,
+  existingDOIs: Set<string>,
+  addedThisSession: Set<string>,
+): boolean {
+  const doi = cleanDoi(work);
+  if (doi && existingDOIs.has(doi)) return true;
+  return addedThisSession.has(shortWorkId(work));
+}
+
+/**
+ * First-author surname sort key. Uses the last name token, but folds known
+ * surname prefixes ("de la Cruz", "van der Berg") into the key so they sort by
+ * the prefix, not the given name. Works with no authors sort last.
+ */
+function firstAuthorSortKey(work: OpenAlexWork): string {
+  const name = work.authorships?.[0]?.author?.display_name?.trim();
+  if (!name) return "￿"; // no authors → sort last
+  const tokens = name.split(/\s+/);
+  if (tokens.length <= 1) return tokens[0].toLowerCase();
+  for (let i = 0; i < tokens.length - 1; i++) {
+    if (SURNAME_PREFIXES.has(tokens[i].toLowerCase())) {
+      return tokens.slice(i).join(" ").toLowerCase();
+    }
+  }
+  return tokens[tokens.length - 1].toLowerCase();
+}
+
+export interface NetworkSortContext {
+  sortBy: NetworkSortKey;
+  existingDOIs: Set<string>;
+  addedThisSession: Set<string>;
+}
+
+/**
+ * Comparator for two network works under the active sort mode. Pure: depends
+ * only on the works + context. Unknown publication years always sort last for
+ * both year directions; `not-in-library` floats not-yet-added works first.
+ */
+export function compareNetworkWorks(
+  a: OpenAlexWork,
+  b: OpenAlexWork,
+  ctx: NetworkSortContext,
+): number {
+  switch (ctx.sortBy) {
+    case "fwci-desc":
+      return (b.fwci ?? -1) - (a.fwci ?? -1);
+    case "percentile-desc":
+      return (
+        (b.citation_normalized_percentile?.value ?? -1) -
+        (a.citation_normalized_percentile?.value ?? -1)
+      );
+    case "year-desc":
+    case "year-asc": {
+      const ya = a.publication_year || 0;
+      const yb = b.publication_year || 0;
+      if (!ya && !yb) return 0;
+      if (!ya) return 1; // unknown date → last, regardless of direction
+      if (!yb) return -1;
+      return ctx.sortBy === "year-asc" ? ya - yb : yb - ya;
+    }
+    case "author-asc": {
+      const ka = firstAuthorSortKey(a);
+      const kb = firstAuthorSortKey(b);
+      if (ka !== kb) return ka < kb ? -1 : 1;
+      const ya = a.publication_year || 0;
+      const yb = b.publication_year || 0;
+      if (ya !== yb) return ya - yb;
+      return (a.display_name || a.title || "").localeCompare(b.display_name || b.title || "");
+    }
+    case "not-in-library": {
+      const ia = isWorkInLibrary(a, ctx.existingDOIs, ctx.addedThisSession);
+      const ib = isWorkInLibrary(b, ctx.existingDOIs, ctx.addedThisSession);
+      if (ia !== ib) return ia ? 1 : -1; // not-in-library first
+      return (b.cited_by_count || 0) - (a.cited_by_count || 0);
+    }
+    default:
+      return (b.cited_by_count || 0) - (a.cited_by_count || 0);
+  }
+}
+
+/** Does a work match the free-text filter (title or any author name)? */
+function matchesFilter(work: OpenAlexWork, lowerFilter: string): boolean {
+  return (
+    work.display_name?.toLowerCase().includes(lowerFilter) ||
+    work.title?.toLowerCase().includes(lowerFilter) ||
+    (work.authorships?.some((a) => a.author.display_name.toLowerCase().includes(lowerFilter)) ??
+      false)
+  );
+}
+
+export interface NetworkVisibilityOptions extends NetworkSortContext {
+  hideInLibrary: boolean;
+}
+
+/**
+ * Apply the free-text filter + optional hide-in-library filter, then sort.
+ * Returns a new array; never mutates the input. Single source of truth for
+ * which works the results list shows and in what order.
+ */
+export function getVisibleNetworkWorks(
+  works: OpenAlexWork[],
+  filter: string,
+  opts: NetworkVisibilityOptions,
+): OpenAlexWork[] {
+  let result = works;
+  const trimmed = filter.trim().toLowerCase();
+  if (trimmed) result = result.filter((w) => matchesFilter(w, trimmed));
+  if (opts.hideInLibrary) {
+    result = result.filter((w) => !isWorkInLibrary(w, opts.existingDOIs, opts.addedThisSession));
+  }
+  return [...result].sort((a, b) => compareNetworkWorks(a, b, opts));
+}
+
 export function renderResults(state: NetworkState, filter = ""): void {
   const body = state.dialog.querySelector(".cg-dialog-body") as HTMLElement;
   if (!body) return;
 
-  let results = state.results;
-
-  if (filter) {
-    const lower = filter.toLowerCase();
-    results = results.filter(
-      (w) =>
-        w.display_name?.toLowerCase().includes(lower) ||
-        w.title?.toLowerCase().includes(lower) ||
-        w.authorships?.some((a) => a.author.display_name.toLowerCase().includes(lower)),
-    );
-  }
-
-  results = [...results].sort((a, b) => {
-    switch (state.sortBy) {
-      case "fwci-desc":
-        return (b.fwci ?? -1) - (a.fwci ?? -1);
-      case "percentile-desc":
-        return (
-          (b.citation_normalized_percentile?.value ?? -1) -
-          (a.citation_normalized_percentile?.value ?? -1)
-        );
-      case "year-desc":
-        return (b.publication_year || 0) - (a.publication_year || 0);
-      case "year-asc":
-        return (a.publication_year || 0) - (b.publication_year || 0);
-      default:
-        return (b.cited_by_count || 0) - (a.cited_by_count || 0);
-    }
+  let results = getVisibleNetworkWorks(state.results, filter, {
+    sortBy: state.sortBy,
+    hideInLibrary: state.hideInLibrary,
+    existingDOIs: state.existingDOIs,
+    addedThisSession: state.addedThisSession,
   });
 
   if (results.length === 0 && !state.loading) {
-    const msg = filter
-      ? `<div class="cg-empty"><div class="cg-empty-title">No matches</div>Try a different search term</div>`
-      : `<div class="cg-empty"><div class="cg-empty-title">No results</div>This work has no ${state.mode === "citing" ? "citing works" : "references"} in OpenAlex</div>`;
+    let msg: string;
+    if (filter) {
+      msg = `<div class="cg-empty"><div class="cg-empty-title">No matches</div>Try a different search term</div>`;
+    } else if (state.hideInLibrary && state.results.length > 0) {
+      msg = `<div class="cg-empty"><div class="cg-empty-title">Nothing new here</div>Every ${state.mode === "citing" ? "citing work" : "reference"} is already in your library. Turn off “Hide in library” to see them.</div>`;
+    } else {
+      msg = `<div class="cg-empty"><div class="cg-empty-title">No results</div>This work has no ${state.mode === "citing" ? "citing works" : "references"} in OpenAlex</div>`;
+    }
     safeInnerHTML(body, msg);
     return;
   }

--- a/src/modules/citationNetwork/styles.ts
+++ b/src/modules/citationNetwork/styles.ts
@@ -49,42 +49,71 @@ export function getDialogCSS(): string {
     }
     #citegeist-network-dialog * { box-sizing: border-box; }
 
-    /* ── Header ── */
-    .cg-dialog-header {
-      display: flex; align-items: center; gap: 10px;
-      padding: 12px 14px;
-      border-bottom: 1px solid var(--cg-sage-tint-15);
+    /* ── Chrome (close bar) ── */
+    .cg-dialog-chrome {
+      display: flex; align-items: center;
+      padding: 5px 14px;
+      background: var(--cg-sage-tint-04);
+      border-bottom: 1px solid var(--cg-sage-tint-08);
       flex-shrink: 0;
     }
     .cg-close-btn {
-      width: 24px; height: 24px; border-radius: 6px;
+      width: 22px; height: 22px; border-radius: 6px;
       border: none; background: var(--cg-red-bg); color: var(--cg-red-fg);
-      font-size: 15px; line-height: 1; cursor: pointer;
+      font-size: 14px; line-height: 1; cursor: pointer;
       display: flex; align-items: center; justify-content: center;
       flex-shrink: 0; padding: 0;
       transition: background 0.12s, color 0.12s;
     }
     .cg-close-btn:hover { background: var(--cg-red-bg-hover); color: var(--cg-red-fg-hover); }
     .cg-close-btn:focus-visible { outline: 2px solid var(--cg-sage-accent); outline-offset: 1px; }
-    .cg-header-text { flex: 1; min-width: 0; }
-    .cg-dialog-title {
-      font-size: 11px; font-weight: 500; color: var(--cg-text-secondary);
-      font-style: italic; letter-spacing: 0;
+
+    /* ── Top band: source title, metadata, cited-by stat ── */
+    .cg-dialog-top {
+      display: grid; grid-template-columns: minmax(0, 1fr) auto;
+      align-items: center; gap: 14px;
+      padding: 13px 14px 11px;
+      border-bottom: 1px solid var(--cg-sage-tint-12);
+      flex-shrink: 0;
+    }
+    .cg-header-text { min-width: 0; }
+    .cg-dialog-eyebrow {
+      font-size: 11px; font-weight: 600; color: var(--cg-text-tertiary);
+      text-transform: uppercase; letter-spacing: 0.06em;
       font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
     }
-    .cg-dialog-subtitle {
-      font-size: 13px; font-weight: 600; color: var(--cg-text-primary);
-      margin-top: 1px;
+    .cg-dialog-title {
+      font-size: 13px; font-weight: 650; color: var(--cg-text-primary);
+      margin-top: 2px;
       white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
       font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
     }
+    .cg-source-authors {
+      font-size: 11px; color: var(--cg-text-tertiary); margin-top: 3px;
+      white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+      font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+    }
+    .cg-count-stack { display: flex; align-items: center; gap: 8px; white-space: nowrap; }
+    .cg-stat {
+      min-width: 72px; text-align: right;
+      border: 1px solid var(--cg-sage-tint-15);
+      border-radius: 7px; padding: 6px 9px;
+      background: var(--cg-sage-tint-06);
+    }
+    .cg-stat-value {
+      display: block; font-size: 14px; line-height: 1; color: var(--cg-text-primary);
+      font-variant-numeric: tabular-nums;
+    }
+    .cg-stat-label { font-size: 10px; color: var(--cg-text-tertiary); }
 
-    /* ── Tabs ── */
-    .cg-dialog-tabs {
-      display: flex; gap: 1px; padding: 8px 14px;
-      flex-shrink: 0;
+    /* ── Command bar: mode + search + filter + sort ── */
+    .cg-command-bar {
+      display: grid; grid-template-columns: auto minmax(160px, 1fr) auto;
+      align-items: center; gap: 8px;
+      padding: 9px 14px;
       background: var(--cg-sage-tint-04);
       border-bottom: 1px solid var(--cg-sage-tint-10);
+      flex-shrink: 0;
     }
     .cg-tabs-inner {
       display: flex; gap: 1px;
@@ -92,30 +121,22 @@ export function getDialogCSS(): string {
       border-radius: 7px; padding: 2px;
     }
     .cg-tab {
-      padding: 7px 16px; font-size: 11px; font-weight: 500; min-height: 24px;
+      padding: 7px 14px; font-size: 11px; font-weight: 600; min-height: 28px;
       cursor: pointer; border: none; background: transparent;
       color: var(--cg-text-secondary); border-radius: 5px;
       transition: background 0.15s, color 0.15s;
       font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
     }
-    .cg-tab.active { background: var(--cg-sage-tint-16); color: var(--cg-text-primary); font-weight: 600; }
+    .cg-tab.active { background: var(--cg-sage-tint-16); color: var(--cg-text-primary); }
     .cg-tab:hover:not(.active) { color: var(--cg-text-hover); }
     .cg-tab:focus-visible { outline: 2px solid var(--cg-sage-accent); outline-offset: 1px; }
-
-    /* ── Toolbar ── */
-    .cg-dialog-toolbar {
-      display: flex; align-items: center; gap: 8px;
-      padding: 8px 14px;
-      border-bottom: 1px solid var(--cg-sage-tint-10);
-      flex-shrink: 0;
-    }
-    .cg-search-wrap { flex: 1; position: relative; }
+    .cg-search-wrap { position: relative; min-width: 0; }
     .cg-search-icon {
-      position: absolute; left: 8px; top: 50%; transform: translateY(-50%);
+      position: absolute; left: 10px; top: 50%; transform: translateY(-50%);
       color: var(--cg-text-quaternary); font-size: 12px; pointer-events: none;
     }
     .cg-search-input {
-      width: 100%; padding: 6px 10px 6px 28px;
+      width: 100%; padding: 7px 10px 7px 30px;
       border: 1px solid var(--cg-sage-tint-15);
       border-radius: 7px; font-size: 12px;
       background: var(--cg-sage-tint-06); color: var(--cg-text-primary); outline: none;
@@ -128,6 +149,41 @@ export function getDialogCSS(): string {
       background: var(--cg-sage-tint-08);
     }
     .cg-search-input::placeholder { color: var(--cg-text-quaternary); }
+    .cg-control-cluster { display: flex; align-items: center; gap: 6px; }
+    .cg-hide-in-library {
+      display: inline-flex; align-items: center; gap: 7px;
+      min-height: 32px; padding: 7px 9px;
+      border: 1px solid var(--cg-sage-tint-15); border-radius: 7px;
+      background: var(--cg-sage-tint-06); color: var(--cg-text-secondary);
+      font-size: 11px; font-weight: 600; cursor: pointer; white-space: nowrap;
+      transition: background 0.12s, color 0.12s, border-color 0.12s;
+      font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+    }
+    .cg-hide-in-library:hover { color: var(--cg-text-hover); }
+    .cg-hide-in-library:focus-visible { outline: 2px solid var(--cg-sage-accent); outline-offset: 1px; }
+    .cg-hide-in-library.cg-switch-on {
+      color: var(--cg-text-primary); border-color: rgba(143,173,159,0.4);
+      background: var(--cg-sage-tint-16);
+    }
+    .cg-switch {
+      position: relative; width: 25px; height: 14px; border-radius: 999px;
+      background: var(--cg-sage-tint-22); flex-shrink: 0;
+      transition: background 0.12s;
+    }
+    .cg-switch::after {
+      content: ""; position: absolute; top: 2px; left: 2px;
+      width: 10px; height: 10px; border-radius: 50%;
+      background: var(--cg-text-quaternary); transition: transform 0.12s, background 0.12s;
+    }
+    .cg-hide-in-library.cg-switch-on .cg-switch { background: var(--cg-sage-accent-tint-25); }
+    .cg-hide-in-library.cg-switch-on .cg-switch::after {
+      transform: translateX(11px); background: var(--cg-sage-accent);
+    }
+    .cg-sort-label {
+      display: inline-flex; align-items: center; gap: 5px;
+      font-size: 11px; color: var(--cg-text-tertiary); white-space: nowrap;
+      font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+    }
     .cg-sort-select {
       padding: 6px 8px; border: 1px solid var(--cg-sage-tint-15);
       border-radius: 7px; font-size: 11px;
@@ -135,6 +191,10 @@ export function getDialogCSS(): string {
       font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
     }
     .cg-sort-select:focus-visible { outline: 2px solid var(--cg-sage-accent); outline-offset: 1px; }
+    @media (max-width: 600px) {
+      .cg-dialog-top, .cg-command-bar { grid-template-columns: 1fr; }
+      .cg-count-stack, .cg-control-cluster, .cg-tabs-inner { width: 100%; }
+    }
 
     /* ── Results body ── */
     .cg-dialog-body { flex: 1; overflow-y: auto; padding: 0; min-height: 300px; }

--- a/src/modules/citationNetwork/types.ts
+++ b/src/modules/citationNetwork/types.ts
@@ -12,6 +12,21 @@ export { MAX_RENDERED_RESULTS, UNDO_TIMEOUT_MS } from "../../constants";
 /** Explicit lifecycle state so guards against closed-mid-load are obvious. */
 export type DialogPhase = "loading-skeleton" | "loading-data" | "ready" | "closed";
 
+/**
+ * Sort modes for the citation network results. `citations`, `fwci-desc`,
+ * `percentile-desc`, `year-desc`, and `year-asc` rank by a metric; `author-asc`
+ * orders by first-author surname; `not-in-library` floats works you haven't
+ * added yet to the top so new discoveries are easy to spot.
+ */
+export type NetworkSortKey =
+  | "citations"
+  | "fwci-desc"
+  | "percentile-desc"
+  | "year-desc"
+  | "year-asc"
+  | "author-asc"
+  | "not-in-library";
+
 /** Common surname prefixes that belong with the last name, not the first. */
 export const SURNAME_PREFIXES = new Set([
   "van",
@@ -55,7 +70,9 @@ export interface NetworkState {
   cursor: string;
   hasMore: boolean;
   loading: boolean;
-  sortBy: string;
+  sortBy: NetworkSortKey;
+  /** When true, results already in the user's library are hidden. */
+  hideInLibrary: boolean;
   existingDOIs: Set<string>;
   /** Incremented on tab switch to invalidate in-flight requests */
   generation: number;

--- a/test/citationNetwork-dialog.test.ts
+++ b/test/citationNetwork-dialog.test.ts
@@ -1,0 +1,131 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { buildDialogHTML, getItemSourceMetaLine } from "../src/modules/citationNetwork/dialog";
+
+function makeItem(opts: {
+  creators?: Array<{ lastName?: string; name?: string; creatorTypeID?: number }>;
+  publicationTitle?: string;
+  date?: string;
+}): _ZoteroTypes.Item {
+  return {
+    getCreators: () => opts.creators ?? [],
+    getField: (field: string) => {
+      if (field === "publicationTitle") return opts.publicationTitle ?? "";
+      if (field === "date") return opts.date ?? "";
+      return "";
+    },
+  } as unknown as _ZoteroTypes.Item;
+}
+
+describe("getItemSourceMetaLine", () => {
+  beforeEach(() => {
+    // No Zotero.CreatorTypes → all creators are treated as authors.
+    vi.stubGlobal("Zotero", {});
+  });
+
+  it("formats up to three authors as surnames · venue · year", () => {
+    const item = makeItem({
+      creators: [{ lastName: "Smith" }, { lastName: "de la Cruz" }, { lastName: "Ng" }],
+      publicationTitle: "Journal of Marketing",
+      date: "2024-03-15",
+    });
+    expect(getItemSourceMetaLine(item)).toBe(
+      "Smith, de la Cruz & Ng · Journal of Marketing · 2024",
+    );
+  });
+
+  it("collapses more than three authors to 'et al.' and parses year from messy dates", () => {
+    const item = makeItem({
+      creators: [
+        { lastName: "Smith" },
+        { lastName: "Jones" },
+        { lastName: "Patel" },
+        { lastName: "Garcia" },
+      ],
+      publicationTitle: "Science",
+      date: "Spring 2021",
+    });
+    expect(getItemSourceMetaLine(item)).toBe("Smith et al. · Science · 2021");
+  });
+
+  it("uses the two-author '&' form", () => {
+    expect(getItemSourceMetaLine(makeItem({ creators: [{ lastName: "Solo" }] }))).toBe("Solo");
+    expect(
+      getItemSourceMetaLine(makeItem({ creators: [{ lastName: "Ada" }, { lastName: "Bo" }] })),
+    ).toBe("Ada & Bo");
+  });
+
+  it("drops missing parts and returns empty string when nothing is available", () => {
+    expect(getItemSourceMetaLine(makeItem({ publicationTitle: "Nature" }))).toBe("Nature");
+    expect(getItemSourceMetaLine(makeItem({ date: "2019" }))).toBe("2019");
+    expect(getItemSourceMetaLine(makeItem({}))).toBe("");
+  });
+
+  it("falls back to single-field creator 'name' when lastName is absent", () => {
+    const item = makeItem({ creators: [{ name: "World Health Organization" }], date: "2020" });
+    expect(getItemSourceMetaLine(item)).toBe("World Health Organization · 2020");
+  });
+});
+
+describe("buildDialogHTML", () => {
+  it("renders the redesigned chrome + command bar with the source meta line", () => {
+    const html = buildDialogHTML("Brand love", "Batra, Ahuvia & Bagozzi · J. Marketing · 2012");
+    expect(html).toContain('class="cg-dialog-chrome"');
+    expect(html).toContain('class="cg-dialog-top"');
+    expect(html).toContain('class="cg-command-bar"');
+    expect(html).toContain('id="cg-source-cited-count"');
+    expect(html).toContain('id="cg-hide-in-library"');
+    expect(html).toContain('class="cg-source-authors"');
+    expect(html).toContain("Brand love");
+    expect(html).toContain("Batra, Ahuvia &amp; Bagozzi · J. Marketing · 2012");
+  });
+
+  it("escapes the title and the source meta line", () => {
+    const html = buildDialogHTML("Title <One> & Two", "Smith & Jones · Journal <X>");
+    expect(html).toContain("Title &lt;One&gt; &amp; Two");
+    expect(html).toContain("Smith &amp; Jones · Journal &lt;X&gt;");
+    expect(html).not.toContain("<One>");
+  });
+
+  it("omits the source-meta element when the meta line is empty", () => {
+    const html = buildDialogHTML("Only title", "");
+    expect(html).not.toContain("cg-source-authors");
+  });
+
+  it("preserves every selector the dialog event wiring depends on", () => {
+    const html = buildDialogHTML("t", "m");
+    for (const sel of [
+      'id="cg-btn-close"',
+      'aria-label="Close citation network browser"',
+      'class="cg-tab"',
+      'data-mode="citing"',
+      'data-mode="references"',
+      'id="cg-tab-citing"',
+      'id="cg-tab-references"',
+      'aria-controls="cg-dialog-body"',
+      'class="cg-search-input"',
+      'class="cg-sort-select"',
+      'id="cg-dialog-body"',
+      'id="cg-total-count"',
+      'id="cg-default-chip"',
+      'id="cg-default-label"',
+      'id="cg-default-dropdown"',
+    ]) {
+      expect(html, `missing selector: ${sel}`).toContain(sel);
+    }
+  });
+
+  it("includes all sort options including the new author + not-in-library modes", () => {
+    const html = buildDialogHTML("t", "m");
+    for (const v of [
+      "citations",
+      "fwci-desc",
+      "percentile-desc",
+      "year-desc",
+      "year-asc",
+      "author-asc",
+      "not-in-library",
+    ]) {
+      expect(html).toContain(`value="${v}"`);
+    }
+  });
+});

--- a/test/citationNetwork-results.test.ts
+++ b/test/citationNetwork-results.test.ts
@@ -1,0 +1,218 @@
+import { describe, expect, it } from "vitest";
+import {
+  compareNetworkWorks,
+  getVisibleNetworkWorks,
+  isWorkInLibrary,
+  type NetworkSortContext,
+} from "../src/modules/citationNetwork/results";
+import type { NetworkSortKey } from "../src/modules/citationNetwork/types";
+import type { OpenAlexWork } from "../src/modules/openalex";
+
+function author(display_name: string) {
+  return { author: { id: "", display_name }, institutions: [] };
+}
+
+function work(p: Partial<OpenAlexWork> & { id: string }): OpenAlexWork {
+  return {
+    id: p.id,
+    doi: p.doi ?? null,
+    display_name: p.display_name ?? "",
+    title: p.title ?? p.display_name ?? "",
+    publication_year: p.publication_year ?? null,
+    cited_by_count: p.cited_by_count ?? 0,
+    fwci: p.fwci ?? null,
+    citation_normalized_percentile: p.citation_normalized_percentile ?? null,
+    authorships: p.authorships ?? [],
+    ...p,
+  } as OpenAlexWork;
+}
+
+function titlesFor(
+  sortBy: NetworkSortKey,
+  works: OpenAlexWork[],
+  existingDOIs = new Set<string>(),
+  addedThisSession = new Set<string>(),
+): string[] {
+  return getVisibleNetworkWorks(works, "", {
+    sortBy,
+    hideInLibrary: false,
+    existingDOIs,
+    addedThisSession,
+  }).map((w) => w.display_name);
+}
+
+describe("citation network sorting", () => {
+  it("sorts by citation count (default) descending", () => {
+    const works = [
+      work({ id: "W1", display_name: "low", cited_by_count: 5 }),
+      work({ id: "W2", display_name: "high", cited_by_count: 500 }),
+      work({ id: "W3", display_name: "mid", cited_by_count: 50 }),
+    ];
+    expect(titlesFor("citations", works)).toEqual(["high", "mid", "low"]);
+  });
+
+  it("sorts by FWCI desc, nulls last", () => {
+    const works = [
+      work({ id: "W1", display_name: "none", fwci: null }),
+      work({ id: "W2", display_name: "big", fwci: 3.2 }),
+      work({ id: "W3", display_name: "small", fwci: 0.4 }),
+    ];
+    expect(titlesFor("fwci-desc", works)).toEqual(["big", "small", "none"]);
+  });
+
+  it("sorts by percentile desc, nulls last", () => {
+    const works = [
+      work({ id: "W1", display_name: "p10", citation_normalized_percentile: { value: 0.1 } }),
+      work({ id: "W2", display_name: "none", citation_normalized_percentile: null }),
+      work({ id: "W3", display_name: "p99", citation_normalized_percentile: { value: 0.99 } }),
+    ];
+    expect(titlesFor("percentile-desc", works)).toEqual(["p99", "p10", "none"]);
+  });
+
+  it("keeps unknown publication dates last for BOTH year directions", () => {
+    const works = [
+      work({ id: "W1", display_name: "unknown", publication_year: null }),
+      work({ id: "W2", display_name: "older", publication_year: 2010 }),
+      work({ id: "W3", display_name: "newer", publication_year: 2020 }),
+    ];
+    expect(titlesFor("year-asc", works)).toEqual(["older", "newer", "unknown"]);
+    expect(titlesFor("year-desc", works)).toEqual(["newer", "older", "unknown"]);
+  });
+
+  it("sorts by first-author surname, folding multi-word prefixes, no-author last", () => {
+    const works = [
+      work({
+        id: "W1",
+        display_name: "Later Smith",
+        publication_year: 2022,
+        authorships: [author("Alice Smith")],
+      }),
+      work({
+        id: "W2",
+        display_name: "Earlier Smith",
+        publication_year: 2020,
+        authorships: [author("Bob Smith")],
+      }),
+      work({
+        id: "W3",
+        display_name: "Cruz Paper",
+        publication_year: 2019,
+        authorships: [author("Maria de la Cruz")],
+      }),
+      work({
+        id: "W4",
+        display_name: "Berg Paper",
+        publication_year: 2021,
+        authorships: [author("Jan van der Berg")],
+      }),
+      work({ id: "W5", display_name: "No Author", publication_year: 2018, authorships: [] }),
+    ];
+    // de la Cruz < Smith(Bob 2020) < Smith(Alice 2022) < van der Berg < (no author)
+    expect(titlesFor("author-asc", works)).toEqual([
+      "Cruz Paper",
+      "Earlier Smith",
+      "Later Smith",
+      "Berg Paper",
+      "No Author",
+    ]);
+  });
+
+  it("floats works not in the library first, then by citation count", () => {
+    const works = [
+      work({
+        id: "W1",
+        display_name: "Already",
+        doi: "https://doi.org/10.1/in",
+        cited_by_count: 100,
+      }),
+      work({ id: "W2", display_name: "Missing higher", cited_by_count: 50 }),
+      work({ id: "W3", display_name: "Missing lower", cited_by_count: 5 }),
+      work({ id: "W4", display_name: "Added", cited_by_count: 200 }),
+    ];
+    const order = titlesFor("not-in-library", works, new Set(["10.1/in"]), new Set(["W4"]));
+    expect(order).toEqual(["Missing higher", "Missing lower", "Added", "Already"]);
+  });
+});
+
+describe("getVisibleNetworkWorks filtering", () => {
+  const ctx = (over: Partial<NetworkSortContext & { hideInLibrary: boolean }> = {}) => ({
+    sortBy: "citations" as NetworkSortKey,
+    hideInLibrary: false,
+    existingDOIs: new Set<string>(),
+    addedThisSession: new Set<string>(),
+    ...over,
+  });
+
+  it("matches the free-text filter against title and author names", () => {
+    const works = [
+      work({
+        id: "W1",
+        display_name: "Brand love and loyalty",
+        authorships: [author("Ada Smith")],
+      }),
+      work({ id: "W2", display_name: "Unrelated topic", authorships: [author("Bo Jones")] }),
+      work({ id: "W3", display_name: "Something else", authorships: [author("Brandon Cole")] }),
+    ];
+    // "brand" matches W1 title and W3 author "Brandon"
+    expect(
+      getVisibleNetworkWorks(works, "brand", ctx())
+        .map((w) => w.id)
+        .sort(),
+    ).toEqual(["W1", "W3"]);
+  });
+
+  it("hides works already in the library when hideInLibrary is on", () => {
+    const works = [
+      work({ id: "W1", display_name: "in via doi", doi: "https://doi.org/10.1/in" }),
+      work({ id: "W2", display_name: "Missing" }),
+      work({ id: "W3", display_name: "in via session" }),
+    ];
+    const visible = getVisibleNetworkWorks(
+      works,
+      "",
+      ctx({
+        hideInLibrary: true,
+        existingDOIs: new Set(["10.1/in"]),
+        addedThisSession: new Set(["W3"]),
+      }),
+    );
+    expect(visible.map((w) => w.display_name)).toEqual(["Missing"]);
+  });
+
+  it("does not mutate the input array", () => {
+    const works = [work({ id: "W1", cited_by_count: 1 }), work({ id: "W2", cited_by_count: 9 })];
+    const before = works.map((w) => w.id);
+    getVisibleNetworkWorks(works, "", ctx());
+    expect(works.map((w) => w.id)).toEqual(before);
+  });
+});
+
+describe("isWorkInLibrary", () => {
+  it("is true when the DOI is in existingDOIs (case-insensitive, prefix-stripped)", () => {
+    const w = work({ id: "W1", doi: "https://doi.org/10.1/ABC" });
+    expect(isWorkInLibrary(w, new Set(["10.1/abc"]), new Set())).toBe(true);
+  });
+
+  it("is true when the short work id was added this session", () => {
+    const w = work({ id: "https://openalex.org/W42" });
+    expect(isWorkInLibrary(w, new Set(), new Set(["W42"]))).toBe(true);
+  });
+
+  it("is false otherwise", () => {
+    const w = work({ id: "W1", doi: "https://doi.org/10.1/x" });
+    expect(isWorkInLibrary(w, new Set(["10.1/y"]), new Set(["W2"]))).toBe(false);
+  });
+});
+
+describe("compareNetworkWorks is a stable pure comparator", () => {
+  it("returns 0 for equal-by-metric works without throwing", () => {
+    const ctx: NetworkSortContext = {
+      sortBy: "citations",
+      existingDOIs: new Set(),
+      addedThisSession: new Set(),
+    };
+    const a = work({ id: "W1", cited_by_count: 10 });
+    const b = work({ id: "W2", cited_by_count: 10 });
+    expect(compareNetworkWorks(a, b, ctx)).toBe(0);
+  });
+});


### PR DESCRIPTION
Implements the deferred **citation network browser redesign** (one of the two features cut from the 2.0 release and tracked in BACKLOG). Built fresh against the [toolbar mockup](../blob/feat/citation-network-redesign/docs/mockups/citation-network-toolbar-ux.html), with tests written for what's actually built.

## What's new (user-facing)

- **Header with source context.** The dialog now leads with the source paper's title, a `Authors · Venue · Year` line, and its own **Cited by** count — instead of just the title. Layout follows the mockup's "command surface" direction (chrome → top band → command bar).
- **Two new sort modes:**
  - **First author** — by first-author surname, folding multi-word prefixes ("de la Cruz", "van der Berg") so they sort by the family name; works with no authors sort last.
  - **Not in library first** — floats works you haven't added yet to the top, so new discoveries stand out.
- **Hide in library** toggle — drops works already in your library (by DOI or added this session) so the list shows only new works.
- Unknown publication dates now sort **last** in both year directions (previously sorted first under "Oldest").

## Implementation

- Sort/filter logic extracted from `renderResults` into pure, unit-tested functions: `compareNetworkWorks`, `getVisibleNetworkWorks`, `isWorkInLibrary` (`results.ts`); `getItemSourceMetaLine` (`dialog.ts`).
- `buildDialogHTML(title, sourceMetaLine)` rewritten to the new structure. **Every selector** `bindDialogEvents` / `loadResults` / `renderResults` depend on (`.cg-tab`, `.cg-search-input`, `.cg-sort-select`, `#cg-dialog-body`, `#cg-total-count`, `#cg-default-chip`, …) is preserved — asserted explicitly in `citationNetwork-dialog.test.ts`.
- New CSS for the chrome / top band / command bar / hide-toggle, using the existing theme tokens (light-dark adaptive).

## Tests / verification

- 23 new tests (`citationNetwork-results.test.ts`, `citationNetwork-dialog.test.ts`); **full suite 317 green**.
- typecheck clean, lint 0 errors, format clean, `npm run build` packages the XPI.

## Scope note

Sorting is **client-side over the loaded page** (same model as before, now with the new modes). Server-side sort of the full paginated set is a follow-up (tracked in BACKLOG). The Zotero plugin UI can't be screenshot-verified in CI, so correctness rests on the unit tests + selector-preservation assertions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)