### PR TITLE
docs: surface the Zenodo archive (DOI badge + CITATION.cff)

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -7,6 +7,14 @@ date-released: "2026-06-07"
 license: GPL-3.0-or-later
 url: "https://github.com/phdemotions/zotero-citegeist"
 repository-code: "https://github.com/phdemotions/zotero-citegeist"
+doi: 10.5281/zenodo.20586895
+identifiers:
+  - type: doi
+    value: 10.5281/zenodo.19433716
+    description: "Concept DOI — always resolves to the latest archived version"
+  - type: doi
+    value: 10.5281/zenodo.20586895
+    description: "Version DOI for v2.0.0"
 abstract: >-
   Citegeist is a Zotero 7+ plugin (compatible with Zotero 8) that embeds citation intelligence
   directly into the reference manager. It displays citation counts,

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
   <a href="https://github.com/phdemotions/zotero-citegeist/releases/latest"><img alt="Latest release" src="https://img.shields.io/github/v/release/phdemotions/zotero-citegeist?style=flat-square&color=5a9cff" /></a>
   <a href="https://github.com/phdemotions/zotero-citegeist/releases/latest"><img alt="Downloads" src="https://img.shields.io/github/downloads/phdemotions/zotero-citegeist/total?style=flat-square&color=30d158" /></a>
   <a href="https://github.com/phdemotions/zotero-citegeist/blob/main/LICENSE"><img alt="License" src="https://img.shields.io/github/license/phdemotions/zotero-citegeist?style=flat-square&color=8e8e93" /></a>
+  <a href="https://doi.org/10.5281/zenodo.19433716"><img alt="DOI" src="https://zenodo.org/badge/DOI/10.5281/zenodo.19433716.svg" /></a>
 </p>
 
 ---


### PR DESCRIPTION
Citegeist is already archived on Zenodo (the repo has been Zenodo-connected since v1.0.0; v2.0.0 auto-archived when its GitHub release published). This just makes it visible + citable:

- **README** — Zenodo DOI badge (concept DOI `10.5281/zenodo.19433716`, which always resolves to the latest archived version).
- **CITATION.cff** — `doi:` for v2.0.0 (`10.5281/zenodo.20586895`) plus both the version and concept DOIs under `identifiers`.

No code change. Confirmed against Zenodo's public records API:
- Concept (all versions): `10.5281/zenodo.19433716`
- v2.0.0: `10.5281/zenodo.20586895`

🤖 Generated with [Claude Code](https://claude.com/claude-code)