### PR TITLE
fix(columns): repaint on batch / collection / library fetch

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -30,6 +30,13 @@ export const FETCH_BATCH_SIZE = 2;
 export const FETCH_BATCH_DELAY_MS = 500;
 /** Delay between calls in a bulk batch fetch (menu-triggered). */
 export const BULK_FETCH_DELAY_MS = 100;
+/**
+ * Debounce for the coalesced column repaint. A burst of per-item cache
+ * invalidations (a collection/library fetch resolving item by item) collapses
+ * into ONE `refreshAndMaintainSelection()` shortly after the last one, so rows
+ * fill in progressively without thrashing the item tree.
+ */
+export const COLUMN_REPAINT_DEBOUNCE_MS = 150;
 
 // ── Citation network dialog ──
 /** Max results rendered in the dialog (soft cap for performance). */

--- a/src/modules/citationColumn.ts
+++ b/src/modules/citationColumn.ts
@@ -18,6 +18,7 @@ import { getCachedSourceISSNs } from "./openalex";
 import { logError, isBookType } from "./utils";
 import {
   AUTO_FETCH_PREF_TTL_MS,
+  COLUMN_REPAINT_DEBOUNCE_MS,
   FETCH_BATCH_DELAY_MS,
   FETCH_BATCH_SIZE,
   FETCH_QUEUE_DEBOUNCE_MS,
@@ -55,6 +56,34 @@ let fetchTimer: ReturnType<typeof setTimeout> | null = null;
 let processingQueue = false;
 const fetchQueue = new Set<number>();
 const fetchAttempted = new Set<number>();
+let repaintTimer: ReturnType<typeof setTimeout> | null = null;
+
+/**
+ * Coalesced, reliable column repaint. `invalidateColumnCache` clears the per-row
+ * memo and fires the lightweight refreshColumns/Notifier signals, but on Zotero
+ * 9 those don't reliably re-run custom column dataProviders —
+ * `refreshAndMaintainSelection()` does. Debounced so a burst of per-item
+ * invalidations (a collection/library fetch landing row by row) collapses into
+ * ONE refresh instead of N, so rows fill in progressively without thrash.
+ */
+function scheduleColumnRepaint(): void {
+  if (repaintTimer) return;
+  repaintTimer = setTimeout(() => {
+    repaintTimer = null;
+    try {
+      const view = Zotero.getActiveZoteroPane()?.itemsView;
+      if (view?.refreshAndMaintainSelection) {
+        void view.refreshAndMaintainSelection();
+      } else if (view?.refresh) {
+        void view.refresh();
+      } else if (view?.invalidate) {
+        view.invalidate();
+      }
+    } catch (e) {
+      logError("scheduleColumnRepaint", e);
+    }
+  }, COLUMN_REPAINT_DEBOUNCE_MS);
+}
 
 /**
  * Build the same namespaced key Zotero stores internally for a
@@ -431,30 +460,15 @@ export async function invalidateColumnCache(itemId?: number | number[]): Promise
     }
   }
   try {
-    // **PRIMARY**: `Zotero.ItemTreeManager.refreshColumns()` is the
-    // public API specifically built for "external data changed,
-    // re-invoke every dataProvider on every visible row". Discovered
-    // by reading the Zotero source at
-    // chrome/content/zotero/xpcom/pluginAPI/itemTreeManager.js
-    // (`refreshColumns() { this._columnManager.refresh(); }`).
-    //
-    // Notifier.trigger alone is necessary but NOT sufficient —
-    // synthetic notifier events without an actual `item.dataModified`
-    // change don't always re-run custom column dataProviders.
+    // Lightweight, immediate signals: ask Zotero to refresh its column manager
+    // and fire the targeted "redraw" Notifier for the affected rows. Necessary
+    // but NOT sufficient on Zotero 9 — neither reliably re-runs a custom column
+    // dataProvider — so we ALSO schedule the coalesced reliable repaint below.
     const refreshFn = (Zotero.ItemTreeManager as unknown as { refreshColumns?: () => void })
       .refreshColumns;
     if (typeof refreshFn === "function") {
       refreshFn.call(Zotero.ItemTreeManager);
     }
-
-    // **Belt-and-suspenders**: fire the canonical "redraw" Notifier
-    // event so item tree handles targeted per-row invalidation. The
-    // "redraw" action is documented in chrome/content/zotero/itemTree.jsx
-    // — it calls `tree.invalidateRow(row)` for the supplied ids
-    // (lighter than the full `refreshColumns` reset above, and
-    // targeted to only the affected rows). Earlier code used "modify"
-    // which is the EVENT FOR ITEM-CONTENT CHANGES, not "this row's
-    // cached data needs re-evaluation"; the latter is "redraw".
     if (ids !== null && ids.length > 0) {
       const notifier = (
         Zotero as unknown as {
@@ -464,22 +478,13 @@ export async function invalidateColumnCache(itemId?: number | number[]): Promise
       notifier?.trigger("redraw", "item", ids);
     }
 
-    // **Fallback** for older builds without refreshColumns.
-    if (typeof refreshFn !== "function") {
-      const zp = Zotero.getActiveZoteroPane();
-      const view = zp?.itemsView;
-      if (view) {
-        if (typeof view.invalidate === "function") view.invalidate();
-        if (typeof view.refresh === "function") {
-          await view.refresh();
-        } else if (typeof view.refreshAndMaintainSelection === "function") {
-          await view.refreshAndMaintainSelection();
-        }
-      }
-    }
-    Zotero.debug(
-      `[Citegeist] invalidateColumnCache: cleared ${ids === null ? "all" : String(ids.length)} entries, refreshColumns=${typeof refreshFn === "function"}`,
-    );
+    // **Reliable repaint.** `refreshAndMaintainSelection()` is what actually
+    // re-evaluates custom dataProviders on Zotero 8/9. It used to be gated
+    // behind `refreshColumns` being ABSENT — so on 8/9 (where refreshColumns
+    // exists) it never ran, and batch / collection / library fetches updated
+    // the cache but never repainted the columns. Always schedule it now; the
+    // debounce coalesces a burst of per-item invalidations into one refresh.
+    scheduleColumnRepaint();
   } catch (e) {
     logError("invalidateColumnCache refresh", e);
   }
@@ -564,15 +569,7 @@ async function processFetchQueue(): Promise<void> {
 
   processingQueue = false;
   metricsCache.clear();
-
-  try {
-    const zp = Zotero.getActiveZoteroPane();
-    if (zp?.itemsView?.refreshAndMaintainSelection) {
-      await zp.itemsView.refreshAndMaintainSelection();
-    }
-  } catch {
-    // Non-critical
-  }
+  scheduleColumnRepaint();
 
   if (fetchQueue.size > 0 && !fetchTimer && registered) {
     fetchTimer = setTimeout(processFetchQueue, FETCH_QUEUE_DEBOUNCE_MS);

--- a/src/modules/citationService.ts
+++ b/src/modules/citationService.ts
@@ -264,14 +264,23 @@ export interface FetchBatchResult {
 export async function fetchAndCacheItems(
   items: _ZoteroTypes.Item[],
   onProgress?: (current: number, total: number) => void,
+  /**
+   * Fired right after each item's fetch resolves, with the item id and the
+   * result status. Lets callers repaint that row's columns AS data lands
+   * (progressive updates over a long collection/library fetch) instead of
+   * waiting for the whole batch to finish.
+   */
+  onItemDone?: (itemId: number, status: string) => void,
 ): Promise<FetchBatchResult> {
   const eligible = items.filter((item) => item.isRegularItem());
 
   const out: FetchBatchResult = { fresh: 0, cached: 0, suggestion: 0, errors: 0 };
 
   for (let i = 0; i < eligible.length; i++) {
+    let status = "error";
     try {
       const result = await fetchAndCacheItem(eligible[i]);
+      status = result.status;
       if (result.status === "ok") out.fresh++;
       else if (result.status === "cached") out.cached++;
       else if (result.status === "suggestion") out.suggestion++;
@@ -281,6 +290,7 @@ export async function fetchAndCacheItems(
       logError(`fetchAndCacheItems item ${eligible[i].id}`, e);
     }
 
+    onItemDone?.(eligible[i].id, status);
     onProgress?.(i + 1, eligible.length);
 
     if (i < eligible.length - 1) {

--- a/src/modules/menu.ts
+++ b/src/modules/menu.ts
@@ -170,10 +170,21 @@ async function runFetchSelected(win: Window): Promise<void> {
 
   let result: BatchResult = { fresh: 0, cached: 0, suggestion: 0, errors: 0 };
   try {
-    result = await fetchAndCacheItems(eligible, (current, total) => {
-      progress.setProgress((current / total) * 100);
-      progress.setText(`${current}/${total} items fetched`);
-    });
+    result = await fetchAndCacheItems(
+      eligible,
+      (current, total) => {
+        progress.setProgress((current / total) * 100);
+        progress.setText(`${current}/${total} items fetched`);
+      },
+      (itemId, status) => {
+        // Repaint each row's columns the moment its data lands, so a long
+        // collection/library fetch fills in progressively instead of all at
+        // the end. The repaint is coalesced/debounced inside the column module.
+        if (status === "ok" || status === "suggestion") {
+          invalidateColumnCache(itemId);
+        }
+      },
+    );
   } catch (e) {
     logError("menu fetch batch", e);
     progress.setProgress(100);
@@ -249,10 +260,21 @@ async function runFetchCollection(win: Window): Promise<void> {
 
   let result: BatchResult = { fresh: 0, cached: 0, suggestion: 0, errors: 0 };
   try {
-    result = await fetchAndCacheItems(eligible, (current, total) => {
-      progress.setProgress((current / total) * 100);
-      progress.setText(`${current}/${total} items fetched`);
-    });
+    result = await fetchAndCacheItems(
+      eligible,
+      (current, total) => {
+        progress.setProgress((current / total) * 100);
+        progress.setText(`${current}/${total} items fetched`);
+      },
+      (itemId, status) => {
+        // Repaint each row's columns the moment its data lands, so a long
+        // collection/library fetch fills in progressively instead of all at
+        // the end. The repaint is coalesced/debounced inside the column module.
+        if (status === "ok" || status === "suggestion") {
+          invalidateColumnCache(itemId);
+        }
+      },
+    );
   } catch (e) {
     logError("menu fetch-collection batch", e);
     progress.setProgress(100);

--- a/test/collection-menu.test.ts
+++ b/test/collection-menu.test.ts
@@ -143,6 +143,7 @@ describe("library root (getSelectedCollection returns null)", () => {
         expect.objectContaining({ id: 2 }),
       ]),
       expect.any(Function),
+      expect.any(Function),
     );
   });
 
@@ -198,6 +199,7 @@ describe("collection selected (getSelectedCollection returns a collection)", () 
     expect(mocks.fetchAndCacheItems).toHaveBeenCalledWith(
       expect.arrayContaining([expect.objectContaining({ id: 5 })]),
       expect.any(Function),
+      expect.any(Function),
     );
   });
 
@@ -243,5 +245,46 @@ describe("collection selected (getSelectedCollection returns a collection)", () 
     const calledWith: _ZoteroTypes.Item[] = mocks.fetchAndCacheItems.mock.calls[0][0];
     const ids = calledWith.map((i) => i.id);
     expect(ids.filter((id) => id === 99)).toHaveLength(1);
+  });
+});
+
+describe("progressive column repaint", () => {
+  it("invalidates each row's columns as its fetch lands, not just at the end", async () => {
+    selectedCollection = makeCollection([makeItem(1), makeItem(2), makeItem(3)]);
+    // Drive the per-item callback the way the real batch loop does.
+    mocks.fetchAndCacheItems.mockImplementationOnce(
+      async (
+        items: Array<{ id: number }>,
+        _onProgress: unknown,
+        onItemDone?: (id: number, status: string) => void,
+      ) => {
+        for (const it of items) onItemDone?.(it.id, "ok");
+        return { fresh: items.length, cached: 0, suggestion: 0, errors: 0 };
+      },
+    );
+    await triggerFetchAll();
+    // Each item's row was invalidated individually (progressive), not only via
+    // a single end-of-batch array invalidation.
+    expect(mocks.invalidateColumnCache).toHaveBeenCalledWith(1);
+    expect(mocks.invalidateColumnCache).toHaveBeenCalledWith(2);
+    expect(mocks.invalidateColumnCache).toHaveBeenCalledWith(3);
+  });
+
+  it("does not invalidate rows whose fetch errored", async () => {
+    selectedCollection = makeCollection([makeItem(1), makeItem(2)]);
+    mocks.fetchAndCacheItems.mockImplementationOnce(
+      async (
+        items: Array<{ id: number }>,
+        _onProgress: unknown,
+        onItemDone?: (id: number, status: string) => void,
+      ) => {
+        onItemDone?.(items[0].id, "ok");
+        onItemDone?.(items[1].id, "error");
+        return { fresh: 1, cached: 0, suggestion: 0, errors: 1 };
+      },
+    );
+    await triggerFetchAll();
+    expect(mocks.invalidateColumnCache).toHaveBeenCalledWith(1);
+    expect(mocks.invalidateColumnCache).not.toHaveBeenCalledWith(2);
   });
 });


### PR DESCRIPTION
**Bug (reported on Zotero 9):** fetching citations for a *single* item updates its columns, but selecting *multiple* items → "Fetch Citation Counts", or a folder/whole-library → "Fetch All Citation Counts", fetched the data but **never repainted the columns**.

## Root cause

1. `invalidateColumnCache` had two repaint signals (`refreshColumns()` + a "redraw" Notifier) plus a reliable one (`refreshAndMaintainSelection()`, the only call that actually re-runs custom column dataProviders on Zotero 8/9). The reliable one was **gated behind `refreshColumns` being absent** — so on Zotero 8/9 it never ran. The auto-fetch queue worked only because it called `refreshAndMaintainSelection()` separately; the menu batch path had no such fallback.
2. The menu batch invalidated **once, at the very end** of a multi-second loop — so even when it did fire, rows didn't fill in progressively.

## Fix

- `invalidateColumnCache` now **always** schedules a **coalesced (debounced)** `refreshAndMaintainSelection()`. A burst of per-item invalidations collapses into one refresh — reliable, no thrash.
- `fetchAndCacheItems` gains a per-item `onItemDone` callback; the menu invalidates **each row as its data lands**, so a long collection/library fetch updates progressively.
- New `COLUMN_REPAINT_DEBOUNCE_MS` constant.

## Tests
- 2 new tests verify per-item invalidation fires for landed items and is skipped for errored ones.
- Full suite **326 green**, typecheck/lint/format/build clean.

Pairs with a second PR (incoming) that fixes the title-match confirm/discard UX. Verify on Zotero 9: select several items (or a folder) → Fetch → columns should fill in row by row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)