### PR TITLE
release: v2.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.2] — 2026-06-08
+
 ### Fixed
 
 - **Dark-mode tints in the citation network browser now render.** The dialog's
@@ -389,6 +391,7 @@ network browser got a thorough pass alongside it:
 - CI pipeline with build, typecheck, and test stages
 - JOSS paper, DESIGN.md, CONTRIBUTING.md, CODE_OF_CONDUCT.md
 
+[2.0.2]: https://github.com/phdemotions/zotero-citegeist/compare/v2.0.1...v2.0.2
 [2.0.1]: https://github.com/phdemotions/zotero-citegeist/compare/v2.0.0...v2.0.1
 [2.0.0]: https://github.com/phdemotions/zotero-citegeist/compare/v1.3.0...v2.0.0
 [1.3.0]: https://github.com/phdemotions/zotero-citegeist/compare/v1.2.1...v1.3.0

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,7 +2,7 @@ cff-version: 1.2.0
 message: "If you use this software, please cite it as below."
 type: software
 title: "Citegeist: Real-Time Citation Intelligence for Business and Management Research"
-version: 2.0.1
+version: 2.0.2
 date-released: "2026-06-08"
 license: GPL-3.0-or-later
 url: "https://github.com/phdemotions/zotero-citegeist"

--- a/docs/ISSUES.md
+++ b/docs/ISSUES.md
@@ -1,6 +1,6 @@
 # Citegeist — Open Issues
 
-> **Last Updated:** 2026-06-08 (v2.0.1 released; counts unchanged)
+> **Last Updated:** 2026-06-08 (v2.0.2 released; DEBT-004 closed — `isBookType` already deduped into `utils.ts`)
 
 ---
 
@@ -28,12 +28,6 @@ _None currently._
 ---
 
 ## P2 — Medium Priority
-
-### DEBT-004: `isBookType` duplicated in `citationColumn.ts` and `citationPane.ts`
-
-**Impact:** When book item types expand (bookChapter, encyclopediaArticle), whoever updates one file will miss the other and the suppression logic silently drifts.
-**Fix:** Extract to `src/modules/utils.ts` as `export function isBookType(item: _ZoteroTypes.Item): boolean`. Both modules already import from utils.
-**Found:** Session audit 2026-04-09 (/wiring 🟠)
 
 ### DEBT-005: `FetchResult` is not a proper discriminated union
 
@@ -88,3 +82,4 @@ _None currently._
 | DEBT-001  | Pane "no identifier" message missing ISBN                                       | Copy updated; `cg-no-doi` → `cg-no-identifier`                                                                         | 2026-04-09 |
 | DEBT-002  | `menu.ts` right-click guards check DOI only                                     | Both guards replaced with `extractIdentifier(item) !== null`                                                           | 2026-04-09 |
 | DEBT-003  | `bumpp` v9.x carries high-severity CVEs in `tar`                                | Upgraded to bumpp@10.4.1 + esbuild@0.28.0                                                                              | 2026-04-09 |
+| DEBT-004  | `isBookType` duplicated in two modules                                          | Extracted to `utils.ts`; `citationColumn.ts` + `citationPane.ts` both import it (confirmed deduped 2026-06-08)         | 2026-06-08 |

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -1,7 +1,7 @@
 # Citegeist — Status
 
 > **Last Updated:** 2026-06-08
-> **Phase:** v2.0.1 released — shipped to GitHub + Zenodo; auto-update channel self-maintaining
+> **Phase:** v2.0.2 released — dark-mode dialog tint fix + canonical design tokens; auto-update channel self-maintaining
 > **Build:** Clean
 
 ---
@@ -10,8 +10,8 @@
 
 | Attribute        | Value                                                                          |
 | ---------------- | ------------------------------------------------------------------------------ |
-| **Version**      | 2.0.1 (released 2026-06-08 — Zenodo DOI 10.5281/zenodo.20596016)               |
-| **Build Status** | Clean (326 tests passing, typecheck clean, lint clean, XPI 90.4 KB)           |
+| **Version**      | 2.0.2 (released 2026-06-08 — Zenodo concept DOI 10.5281/zenodo.19433716)       |
+| **Build Status** | Clean (326 tests passing, typecheck clean, lint clean, XPI 91.9 KB)           |
 | **Open Issues**  | P0: 0, P1: 0, P2: 3, P3: 2 (see ISSUES.md)                                     |
 | **Stack**        | TypeScript 6, esbuild, vitest 4.1, ESLint 10, Zotero 7.0.10–9, SQLite, Node 22 |
 | **Data Source**  | OpenAlex (free, unauthenticated, CC0)                                          |
@@ -21,7 +21,9 @@
 
 ## In Progress
 
-_None — v2.0.1 is released and clean (326 tests, lint clean, build clean)._
+_None — v2.0.2 is released and clean (326 tests, lint clean, build clean)._
+
+**Shipped 2026-06-08 (v2.0.2):** dark-mode citation-network tint fix — the dialog's sage-tint scale had a self-referential dark-theme arm (`light-dark(…, var(--cg-sage-tint-NN))`), invalid at computed-value time, so every dark-mode tint collapsed to transparent; now defined correctly. Design tokens (spacing, radii, type, motion, color ramps) consolidated into a canonical module `src/modules/ui/tokens.ts` that both the item pane and the network dialog consume; `docs/design-system/citegeist-primitives.html` added as the design reference (#45). Pane visually unchanged.
 
 **Shipped 2026-06-08 (v2.0.1):** batch/collection/library column repaint fix (#35), redesigned title-match confirm/discard card (#36), citation network browser improvements — new sort modes (first author, not-in-library) + hide-in-library filter + source-metadata header (#32), Zotero 8+ MenuManager with DOM fallback (#33), Zenodo DOI surfacing (#34), TS6/ESLint10/action-gh-release-v3 deps (#37). v2.0.0 (SQLite cache migration) shipped 2026-06-08 (#30).
 
@@ -156,6 +158,9 @@ See `BACKLOG.md` for full details.
 
 | Version | Date       | Summary                                                                     |
 | ------- | ---------- | --------------------------------------------------------------------------- |
+| 2.0.2   | 2026-06-08 | Dark-mode dialog tint fix; canonical design-token module (both surfaces)    |
+| 2.0.1   | 2026-06-08 | Column repaint fix, redesigned title-match card, network browser sort/filter |
+| 2.0.0   | 2026-06-08 | SQLite-backed cache (migrated from Extra-field storage)                     |
 | 1.0.3   | 2026-04-09 | Non-DOI identifiers (PMID/arXiv/ISBN), rankings refresh (ABDC '25, AJG '24) |
 | 1.0.2   | 2026-04-08 | Family design language, FWCI/percentile sort                                |
 | 1.0.1   | 2026-04-08 | Quality pass: error handling, tooling, tests, docs                          |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zotero-citegeist",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zotero-citegeist",
-      "version": "2.0.1",
+      "version": "2.0.2",
       "license": "GPL-3.0-or-later",
       "devDependencies": {
         "@eslint/js": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zotero-citegeist",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Citation intelligence for Zotero — powered by OpenAlex. See citation counts, explore citation networks, and add citing/cited works to your library.",
   "homepage": "https://github.com/phdemotions/zotero-citegeist",
   "author": "Josh Gonzales",


### PR DESCRIPTION
Cuts **v2.0.2**. Ships what landed in #45 plus release bookkeeping.

### User-facing
- **Dark-mode tints in the citation network browser now render.** The dialog's sage-tint scale had a self-referential dark-theme branch (`light-dark(…, var(--cg-sage-tint-NN))`) — invalid at computed-value time — so every dark-mode tint silently fell to transparent. Fixed.

### Internal
- Canonical design-token module `src/modules/ui/tokens.ts` consumed by both surfaces (item pane + network dialog); `docs/design-system/citegeist-primitives.html` is the reference.
- Version bump across `package.json`, `package-lock.json`, `CITATION.cff`.
- CHANGELOG `[Unreleased]` → `[2.0.2]`.
- STATUS/ISSUES updated; closed stale **DEBT-004** (`isBookType` is already deduped into `utils.ts`).

### Gate
326 tests · typecheck · lint (0 errors) · format · build → `citegeist-2.0.2.xpi` (91.9 KB).

After merge: tag `v2.0.2` on main → `release.yml` builds the XPI, publishes the GitHub Release, refreshes the `release` floating tag (auto-update), and Zenodo archives it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)