### PR TITLE
ci: bump checkout + upload-artifact to Node 24 actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
         # and package.json `engines.node` is pinned to ">=22.0.0".
         node-version: [22]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: actions/setup-node@v6
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: actions/setup-node@v6
         with:
@@ -26,7 +26,7 @@ jobs:
       - run: npm run build
 
       - name: Upload XPI artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: citegeist-xpi
           path: build/*.xpi


### PR DESCRIPTION
`actions/checkout@v4` and `actions/upload-artifact@v4` run on **Node 20**, which GitHub deprecates and force-migrates to **Node 24 on 2026-06-16** (surfaced as an annotation on the v2.0.2 release run). Bumps both to `@v5` ahead of the cutover. `setup-node` is already `@v6`.

- `ci.yml`: `checkout@v4 → v5`
- `release.yml`: `checkout@v4 → v5`, `upload-artifact@v4 → v5`

No behavior change. This PR's own CI run exercises `checkout@v5`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)