### PR TITLE
docs(okf): adopt Open Knowledge Format for the docs/ bundle

### DIFF
--- a/.github/workflows/okf-watch.yml
+++ b/.github/workflows/okf-watch.yml
@@ -1,0 +1,75 @@
+# OKF upstream watch — "track continuously, adopt deliberately".
+#
+# POLICY NOTE: Citegeist is a Zotero plugin (not a Vercel app) and already uses GitHub Actions
+# for releases. This is non-deploy, cross-repo automation (it watches another repo on a
+# schedule), runs NO build, and burns ~seconds/day. Approved by Josh for citegeist in the
+# 2026-06-15 session; mirrors ME2's okf-watch pattern.
+#
+# It diffs the upstream OKF spec (GoogleCloudPlatform/knowledge-catalog okf/SPEC.md) against
+# our pinned commit and opens/updates ONE tracking issue when they diverge. It NEVER re-pins —
+# a human reads the diff and bumps the pin deliberately (chasing an unstable v0.1 draft live is
+# the opposite of future-proofing). See docs/STANDARDS.md -> "Tracking upstream".
+name: OKF upstream watch
+
+on:
+  schedule:
+    - cron: "0 9 * * *" # daily, 09:00 UTC
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: okf-watch
+  cancel-in-progress: false
+
+jobs:
+  drift:
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check OKF upstream drift
+        id: drift
+        run: |
+          set +e
+          out=$(bash tools/okf-drift-check.sh 2>&1); code=$?
+          echo "$out"
+          echo "code=$code" >> "$GITHUB_OUTPUT"
+          {
+            echo 'report<<OKF_EOF'
+            echo "$out"
+            echo OKF_EOF
+          } >> "$GITHUB_OUTPUT"
+          exit 0
+
+      - name: Open or update tracking issue on drift
+        if: steps.drift.outputs.code == '3'
+        env:
+          REPORT: ${{ steps.drift.outputs.report }}
+        run: |
+          title="OKF upstream drift — review + bump pin"
+          {
+            echo "The pinned OKF spec has moved upstream. **Review the diff and bump the pin deliberately — do not auto-follow.**"
+            echo
+            echo '```'
+            printf '%s\n' "$REPORT"
+            echo '```'
+            echo
+            echo "Process: \`docs/STANDARDS.md\` -> \"Tracking upstream\". Bump the pin in \`docs/STANDARDS.md\` + the canonical \`~/developer/docs/standards/okf-adoption.md\` once reviewed."
+          } > /tmp/okf-issue.md
+          existing=$(gh issue list --state open --json number,title \
+            --jq ".[] | select(.title==\"$title\") | .number" | head -1)
+          if [ -n "${existing:-}" ]; then
+            gh issue comment "$existing" --body-file /tmp/okf-issue.md
+          else
+            gh issue create --title "$title" --body-file /tmp/okf-issue.md
+          fi
+
+      - name: Fail on drift-check error
+        if: steps.drift.outputs.code == '2'
+        run: |
+          echo "okf-drift-check.sh errored (gh auth / network / missing pin)"; exit 1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Internal
+
+- Project documentation adopts the Open Knowledge Format (OKF v0.1, pinned): every
+  file under `docs/` carries structured YAML frontmatter with a `type`, validated by
+  `npm run okf:check`, with upstream-spec drift tracked by `npm run okf:drift`.
+  Docs-only — no change to the plugin or build. See `docs/STANDARDS.md`.
+
 ## [2.0.4] — 2026-06-10
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,10 +17,12 @@ npm run lint               # ESLint
 npm run lint:fix           # ESLint --fix
 npm run format             # Prettier write
 npm run format:check       # Prettier check (no write)
+npm run okf:check          # OKF docs-conformance (every docs/ file has a `type`)
+npm run okf:drift          # Compare OKF spec upstream HEAD vs the pinned commit
 npm run release            # Bump version, tag, push (triggers GitHub Actions release)
 ```
 
-**Pre-commit checklist:** `npm run typecheck && npm test && npm run lint && npm run format:check && npm run build`
+**Pre-commit checklist:** `npm run typecheck && npm test && npm run lint && npm run format:check && npm run okf:check && npm run build`
 
 ---
 
@@ -63,6 +65,7 @@ src/
 test/                           # vitest unit tests
 addon/                          # Static addon files (manifest.json, prefs.xhtml, icons)
 scripts/                        # build.mjs, release helpers
+tools/                          # okf-check.sh, okf-drift-check.sh (docs OKF standard)
 typings/                        # Zotero type declarations
 ```
 
@@ -83,6 +86,8 @@ typings/                        # Zotero type declarations
 **HTML safety:** Use `escapeHTML()` for interpolating user data into HTML strings. Use the `safeHTML` tagged template for new code. Never set `.innerHTML` directly — use `safeInnerHTML()` from `utils.ts` which uses DOMParser to handle Zotero's XUL document context correctly.
 
 **Design system (UI colour + theming):** All UI colours come from the canonical `--cg-*` tokens in `src/modules/ui/tokens.ts` (`cgDesignTokens`), consumed by the shared primitives in `ui/components.ts` (`cgComponents`: `.cg-btn` / `.cg-chip` / `.cg-card` / `.cg-banner` / `.cg-eyebrow`). Never hardcode hex or rely on Zotero `--accent-*`/`--fill-*` fallbacks in component CSS — `test/ui-primitives.test.ts` fails on raw hex in a primitive and requires every primitive to be documented in the `docs/design-system/citegeist-primitives.html` gallery (the gallery mirrors the code, which is canonical). Both surfaces force `color-scheme` to Zotero's real theme via `ui/theme.ts` (`resolveHostScheme`) so `light-dark()` follows the host, not the OS; any UI portaled onto `doc.body` must do the same.
+
+**Documentation standard (OKF — docs only, NOT code):** Every file under `docs/` conforms to the Open Knowledge Format (OKF v0.1), **pinned** to spec commit `ee67a5c` — markdown with YAML frontmatter carrying a required `type`. OKF is a knowledge/metadata format for docs; it is **not a coding standard** — code style stays with `tsc` strict + ESLint + Prettier + `src/constants.ts`. "OKF for our coding" means the code's _knowledge_ (architecture in `docs/DESIGN.md`, the principles here) is captured as OKF docs, not that OKF governs `.ts` syntax. Validate with `npm run okf:check`; compare the upstream spec to the pin with `npm run okf:drift` (monthly review — **never auto-follow `main`**, bump the pin deliberately). Scope, `type` vocabulary, and cadence live in `docs/STANDARDS.md`; the canonical org pin is `~/developer/docs/standards/okf-adoption.md`.
 
 ---
 
@@ -128,6 +133,8 @@ Locally, always verify with `rm -rf node_modules && npm install` before releasin
 | `docs/STATUS.md`      | Current project state, what was done last session, upcoming work |
 | `docs/ISSUES.md`      | Open bugs and feature requests with priorities                   |
 | `docs/BACKLOG.md`     | Curated longer-term enhancement ideas                            |
+| `docs/STANDARDS.md`   | OKF documentation standard — pin, scope (docs-only), cadence     |
+| `docs/index.md`       | OKF bundle catalog (reserved index of every docs/ file)          |
 | `CHANGELOG.md`        | Keep-a-Changelog format, one entry per release                   |
 | `docs/DESIGN.md`      | Architecture decisions and trade-offs                            |
 | `CONTRIBUTING.md`     | Dev setup, commands, PR guidelines                               |

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -1,3 +1,11 @@
+---
+type: backlog
+title: Citegeist — backlog
+description: Curated longer-term enhancement ideas, each a candidate GitHub issue.
+timestamp: 2026-06-08
+tags: [citegeist, backlog, enhancements]
+---
+
 # Citegeist Backlog
 
 A curated list of planned enhancements and ideas for Citegeist. Each item is a candidate for a GitHub issue — contributions are welcome on any of them. If you'd like to pick one up, open an issue (or comment on an existing one) to coordinate.

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -1,3 +1,11 @@
+---
+type: architecture
+title: Citegeist — design rationale
+description: Key architectural decisions behind Citegeist and the trade-offs involved.
+timestamp: 2026-04-09
+tags: [citegeist, architecture, design, openalex, zotero]
+---
+
 # Design Rationale
 
 This document explains the key architectural decisions behind Citegeist and the trade-offs involved. It is intended for reviewers, contributors, and anyone interested in why the plugin works the way it does.

--- a/docs/ISSUES.md
+++ b/docs/ISSUES.md
@@ -1,3 +1,11 @@
+---
+type: issues
+title: Citegeist — open issues
+description: Open bugs and feature requests, tracked by priority.
+timestamp: 2026-06-10
+tags: [citegeist, issues]
+---
+
 # Citegeist — Open Issues
 
 > **Last Updated:** 2026-06-10 (v2.0.4 released #57: DEBT-008 closed — design-primitive unification done: shared chip/card/banner/eyebrow + token-purity & gallery-parity tests + two light-mode contrast fixes. v2.0.3 released #56: theme fix + settings + icon. Earlier: any-identifier browser #50; DEBT-006/007 closed. Closed issues archived to `docs/archive/issues-closed.jsonl`)

--- a/docs/MIGRATION-v2.0.0.md
+++ b/docs/MIGRATION-v2.0.0.md
@@ -1,3 +1,11 @@
+---
+type: migration
+title: Migrating from v1.3.x to v2.0.0
+description: v2.0.0 moves cached citation data from Zotero Extra fields to a plugin-owned SQLite database.
+timestamp: 2026-06-07
+tags: [citegeist, migration, cache, sqlite]
+---
+
 # Migrating from v1.3.x to v2.0.0
 
 > v2.0.0 moves cached citation data out of Zotero item `Extra` fields into a plugin-owned SQLite database. Storage format changed; UI and feature set didn't.

--- a/docs/STANDARDS.md
+++ b/docs/STANDARDS.md
@@ -1,0 +1,79 @@
+---
+type: standard
+title: Citegeist — Documentation & knowledge standard (OKF)
+description: Citegeist's docs/ tree conforms to the Open Knowledge Format (OKF v0.1); how we apply it and track the upstream spec.
+timestamp: 2026-06-15
+tags: [citegeist, standard, okf, documentation, future-proofing]
+---
+
+# Documentation standard — Open Knowledge Format (OKF)
+
+Citegeist's [`docs/`](index.md) tree is an **OKF bundle**: a directory of markdown
+files with YAML frontmatter — human- and agent-readable, diffable, portable. This
+file is the explicit, pinned conformance statement for the plugin.
+
+## Pin (future-proofing starts with a known baseline)
+
+> **Canonical org standard:** [`~/developer/docs/standards/okf-adoption.md`](../../../docs/standards/okf-adoption.md).
+> This file is Citegeist's per-product instance + bundle conformance; the pin below
+> **mirrors** the canonical `okf_pin` — re-pin there first, then here.
+
+- **Spec:** Open Knowledge Format — `GoogleCloudPlatform/knowledge-catalog` → `okf/SPEC.md`
+- **Version:** `0.1` (Draft)
+- **Pinned commit:** `ee67a5ca27044ebe7c38385f5b6cffc2305a9c1a` (2026-06-12)
+- **Retrieved:** 2026-06-15
+- OKF is a **draft, actively-changing** spec. We pin a commit and re-check upstream
+  on a schedule — never silently track `main`. Chasing an unstable draft is the
+  opposite of future-proofing.
+
+## Scope — what OKF does and does NOT cover
+
+- ✅ **Documentation / knowledge** — the `docs/` bundle (design rationale, migration
+  notes, status, issues, backlog, plans, brainstorms, solutions, audits).
+- ❌ **Code syntax** — OKF is a knowledge format, not a linter. Citegeist's code
+  conventions stay where they already live: TypeScript strict (`tsc --noEmit`),
+  ESLint 9 flat config, Prettier, and the "every magic number in `src/constants.ts`"
+  rule (see [`CLAUDE.md`](../CLAUDE.md)). "OKF for our coding" means our code
+  *knowledge* — the architecture decisions in [`DESIGN.md`](DESIGN.md), the
+  principles in `CLAUDE.md` — is captured as OKF-conformant docs. It does **not**
+  mean OKF governs `.ts` syntax; that stays with the toolchain.
+- **Repo-root operational docs** (`README.md`, `CLAUDE.md`, `CHANGELOG.md`,
+  `CONTRIBUTING.md`, `CITATION.cff`) live outside `docs/` and are **not** part of
+  the bundle — kept in their own established formats (Keep-a-Changelog, CFF, …).
+- **`docs/paper/`** is **exempt**: the JOSS `paper.md` carries its own required
+  frontmatter contract (title/tags/authors/affiliations/bibliography). `okf-check.sh`
+  skips it.
+
+## How we conform
+
+- Every non-reserved, non-exempt `docs/**/*.md` carries YAML frontmatter with a
+  non-empty **`type`** (required) plus recommended `title`, `description`,
+  `timestamp` (ISO 8601), and `tags`.
+- Existing extension keys are preserved (`date`, `topic`, `category`, `module`,
+  `status`, `origin`, …) — OKF consumers tolerate unknown keys.
+- Reserved files: **`index.md`** (catalog; declares `okf_version`) and, if added,
+  **`log.md`** (date-grouped history, newest first).
+- **Permissive consumers** — never reject a doc for a missing optional field, an
+  unknown `type`, an extra key, or a broken link.
+
+## Citegeist `type` vocabulary
+
+`standard` · `architecture` · `status` · `issues` · `backlog` · `migration` ·
+`plan` · `feat` · `brainstorm` · `ideation` · `solution` · `audit`. Not centrally
+registered — add types freely; consumers tolerate unknowns.
+
+## Tracking upstream (it changes "all the time")
+
+1. The **pinned commit** above is the baseline; we conform to exactly that.
+2. **Drift check** — `npm run okf:drift` (`bash tools/okf-drift-check.sh`) compares
+   upstream HEAD of `okf/SPEC.md` to the pin (exit `3` = drift). On the monthly
+   review (alongside the dependency audit), run it; on drift: read the diff →
+   update conforming docs → re-pin (canonical `okf-adoption.md` first, then here)
+   → log it. **Never auto-follow `main`.**
+3. **Conformance** — `npm run okf:check` (`bash tools/okf-check.sh`) asserts every
+   bundle doc has a non-empty `type` and the catalog declares `okf_version`.
+4. Treat OKF as a **dependency**: re-pin deliberately, exactly like a package bump.
+
+## Citations
+
+1. OKF specification — https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -1,3 +1,11 @@
+---
+type: status
+title: Citegeist — project status
+description: Current project state, last session's work, and upcoming priorities.
+timestamp: 2026-06-15
+tags: [citegeist, status]
+---
+
 # Citegeist — Status
 
 > **Last Updated:** 2026-06-10

--- a/docs/audits/session-audit-2026-04-09-1545.md
+++ b/docs/audits/session-audit-2026-04-09-1545.md
@@ -1,3 +1,11 @@
+---
+type: audit
+title: Session audit — Citegeist v1.1.0
+description: Cross-lens session audit (cdo · ux · wiring · zeitgeist · freshen) for the v1.1.0 release.
+timestamp: 2026-04-09
+tags: [citegeist, audit, v1.1.0]
+---
+
 # 🧭 Session Audit — Citegeist
 **Date:** 2026-04-09 15:45
 **Scope:** 19 files changed — v1.1.0 (non-DOI identifiers, ISBN support, rankings refresh, DESIGN.md spec)

--- a/docs/audits/session-cdo-2026-04-09-1545.md
+++ b/docs/audits/session-cdo-2026-04-09-1545.md
@@ -1,3 +1,11 @@
+---
+type: audit
+title: "/cdo audit — Citegeist v1.1.0"
+description: Design-excellence (CDO) lens over the v1.1.0 change set.
+timestamp: 2026-04-09
+tags: [citegeist, audit, cdo, v1.1.0]
+---
+
 # /cdo — Citegeist
 **Scope:** 19 files changed this session (v1.1.0 release): `src/modules/openalex.ts`, `src/modules/citationService.ts`, `src/modules/citationPane.ts`, `src/modules/citationColumn.ts`, `src/data/journalRankings.ts`, `typings/zotero.d.ts`, `test/openalex.test.ts`, `test/citationService.test.ts`, `test/journalRankings.test.ts`, `README.md`, `paper/paper.md`, `DESIGN.md`, `BACKLOG.md`, `ISSUES.md`, `STATUS.md`, `CHANGELOG.md`, `package.json`, `package-lock.json`, `CITATION.cff`
 **Date:** 2026-04-09

--- a/docs/audits/session-freshen-2026-04-09-1545.md
+++ b/docs/audits/session-freshen-2026-04-09-1545.md
@@ -1,3 +1,11 @@
+---
+type: audit
+title: "/freshen audit — Citegeist"
+description: devDependency freshness audit (vitest, esbuild, typescript, eslint, prettier, bumpp).
+timestamp: 2026-04-09
+tags: [citegeist, audit, freshen, dependencies]
+---
+
 # /freshen — Citegeist
 **Scope:** devDependencies audit — vitest, esbuild, typescript, @typescript-eslint packages, prettier, bumpp
 **Date:** 2026-04-09

--- a/docs/audits/session-ux-2026-04-09-1545.md
+++ b/docs/audits/session-ux-2026-04-09-1545.md
@@ -1,3 +1,11 @@
+---
+type: audit
+title: "/ux audit — Citegeist v1.1.0"
+description: UX lens over the v1.1.0 change set.
+timestamp: 2026-04-09
+tags: [citegeist, audit, ux, v1.1.0]
+---
+
 # /ux — Citegeist
 **Scope:** 19 files changed this session (v1.1.0): src/modules/openalex.ts, src/modules/citationService.ts, src/modules/citationPane.ts, src/modules/citationColumn.ts, src/data/journalRankings.ts, typings/zotero.d.ts, test/openalex.test.ts, test/citationService.test.ts, test/journalRankings.test.ts, README.md, paper/paper.md, DESIGN.md, BACKLOG.md, ISSUES.md, STATUS.md, CHANGELOG.md, package.json, package-lock.json, CITATION.cff
 **Date:** 2026-04-09

--- a/docs/audits/session-wiring-2026-04-09-1545.md
+++ b/docs/audits/session-wiring-2026-04-09-1545.md
@@ -1,3 +1,11 @@
+---
+type: audit
+title: "/wiring audit — Citegeist v1.1.0"
+description: Data-flow / wiring lens over the v1.1.0 change set.
+timestamp: 2026-04-09
+tags: [citegeist, audit, wiring, v1.1.0]
+---
+
 # /wiring — Citegeist
 **Scope:** 19 files changed this session (v1.1.0 release): src/modules/openalex.ts, src/modules/citationService.ts, src/modules/citationPane.ts, src/modules/citationColumn.ts, src/data/journalRankings.ts, typings/zotero.d.ts, test/openalex.test.ts, test/citationService.test.ts, test/journalRankings.test.ts, DESIGN.md
 **Date:** 2026-04-09

--- a/docs/audits/session-zeitgeist-2026-04-09-1545.md
+++ b/docs/audits/session-zeitgeist-2026-04-09-1545.md
@@ -1,3 +1,11 @@
+---
+type: audit
+title: "/zeitgeist audit — Citegeist v1.1.0"
+description: Holistic zeitgeist lens over the v1.1.0 release.
+timestamp: 2026-04-09
+tags: [citegeist, audit, zeitgeist, v1.1.0]
+---
+
 # /zeitgeist — Citegeist v1.1.0
 
 **Scope:** 19 files — v1.1.0 release: openalex.ts (normalizers + ISBN/PMID/arXiv lookups), citationService.ts (extractIdentifier, FetchResult, ItemIdentifier), citationPane.ts (book zero-suppression, citationSummary), citationColumn.ts (isBookType, book zero-suppression), journalRankings.ts (3177 journals, ISSN_ALIASES), typings/zotero.d.ts, test/openalex.test.ts, test/citationService.test.ts, test/journalRankings.test.ts, DESIGN.md (metadata-matching spec), package.json / package-lock.json

--- a/docs/brainstorms/2026-04-19-citation-pane-metric-grid-requirements.md
+++ b/docs/brainstorms/2026-04-19-citation-pane-metric-grid-requirements.md
@@ -1,4 +1,9 @@
 ---
+type: brainstorm
+title: "Citation-pane metric grid — requirements"
+description: Requirements brainstorm for the equal-weight 3-tile citation-pane metric grid.
+timestamp: 2026-04-19
+tags: [citegeist, brainstorm, citation-pane, ui]
 date: 2026-04-19
 topic: citation-pane-metric-grid
 ---

--- a/docs/ideation/2026-04-19-citation-pane-ui-ideation.md
+++ b/docs/ideation/2026-04-19-citation-pane-ui-ideation.md
@@ -1,4 +1,9 @@
 ---
+type: ideation
+title: "Citation-pane UI — ideation"
+description: Repo-grounded ideation toward an award-winning analytics-dashboard citation pane.
+timestamp: 2026-04-19
+tags: [citegeist, ideation, citation-pane, ui]
 date: 2026-04-19
 topic: citation-pane-ui
 focus: redesign citation pane to award-winning analytics dashboard quality

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,51 @@
+---
+okf_version: "0.1"
+type: index
+title: Citegeist documentation — OKF bundle catalog
+---
+
+# Citegeist docs — OKF bundle
+
+Open Knowledge Format v0.1 bundle. See [`STANDARDS.md`](STANDARDS.md) for the pin,
+scope, and tracking cadence. Repo-root operational docs (`README`, `CLAUDE`,
+`CHANGELOG`, `CONTRIBUTING`, `CITATION.cff`) live outside this bundle; `paper/` is
+JOSS-exempt.
+
+## Standards
+
+- [Documentation standard (OKF)](STANDARDS.md) — pin + scope + tracking cadence
+
+## Project state
+
+- [Status](STATUS.md) — current state, last session, upcoming work
+- [Issues](ISSUES.md) — open bugs and feature requests by priority
+- [Backlog](BACKLOG.md) — curated longer-term enhancement ideas
+
+## Architecture & migration
+
+- [Design rationale](DESIGN.md) — architecture decisions and trade-offs
+- [Migration v2.0.0](MIGRATION-v2.0.0.md) — Extra → SQLite cache move
+
+## Plans
+
+- [Citation-pane metric grid (feat)](plans/2026-04-19-001-feat-citation-pane-metric-grid-plan.md)
+- [SQLite cache migration (feat)](plans/2026-05-27-001-feat-sqlite-cache-migration-plan.md)
+
+## Brainstorms & ideation
+
+- [Citation-pane metric grid — requirements](brainstorms/2026-04-19-citation-pane-metric-grid-requirements.md)
+- [Citation-pane UI — ideation](ideation/2026-04-19-citation-pane-ui-ideation.md)
+
+## Solutions
+
+- [Equal-weight metric tile grid](solutions/ui-bugs/misleading-citation-pane-metric-hierarchy-2026-04-19.md)
+- [Dev install: proxy file vs XPI](solutions/workflow-issues/zotero-plugin-dev-install-proxy-vs-xpi-2026-04-19.md)
+
+## Audits (2026-04-09, v1.1.0)
+
+- [Session audit](audits/session-audit-2026-04-09-1545.md)
+- [/cdo](audits/session-cdo-2026-04-09-1545.md)
+- [/ux](audits/session-ux-2026-04-09-1545.md)
+- [/wiring](audits/session-wiring-2026-04-09-1545.md)
+- [/zeitgeist](audits/session-zeitgeist-2026-04-09-1545.md)
+- [/freshen](audits/session-freshen-2026-04-09-1545.md)

--- a/docs/plans/2026-05-27-001-feat-sqlite-cache-migration-plan.md
+++ b/docs/plans/2026-05-27-001-feat-sqlite-cache-migration-plan.md
@@ -1,3 +1,12 @@
+---
+type: plan
+title: "SQLite cache migration (Extra → plugin-owned DB) — v2"
+description: Approved implementation plan for moving cached metrics from Zotero Extra fields to a plugin-owned SQLite database.
+timestamp: 2026-05-27
+status: approved
+tags: [citegeist, plan, cache, sqlite, migration]
+---
+
 # Plan — SQLite Cache Migration (Extra → Plugin-Owned DB) — v2
 
 > **Date:** 2026-05-27

--- a/docs/solutions/ui-bugs/misleading-citation-pane-metric-hierarchy-2026-04-19.md
+++ b/docs/solutions/ui-bugs/misleading-citation-pane-metric-hierarchy-2026-04-19.md
@@ -1,4 +1,5 @@
 ---
+type: solution
 title: "Equal-weight metric tile grid for Zotero citation pane"
 date: 2026-04-19
 category: docs/solutions/ui-bugs

--- a/docs/solutions/workflow-issues/zotero-plugin-dev-install-proxy-vs-xpi-2026-04-19.md
+++ b/docs/solutions/workflow-issues/zotero-plugin-dev-install-proxy-vs-xpi-2026-04-19.md
@@ -1,4 +1,5 @@
 ---
+type: solution
 title: "Zotero plugin dev install: proxy file vs XPI"
 date: 2026-04-19
 category: docs/solutions/workflow-issues

--- a/package.json
+++ b/package.json
@@ -17,7 +17,9 @@
     "lint": "eslint",
     "lint:fix": "eslint --fix",
     "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\" \"*.{json,md,mjs}\"",
-    "format:check": "prettier --check \"src/**/*.ts\" \"test/**/*.ts\" \"*.mjs\""
+    "format:check": "prettier --check \"src/**/*.ts\" \"test/**/*.ts\" \"*.mjs\"",
+    "okf:check": "bash tools/okf-check.sh",
+    "okf:drift": "bash tools/okf-drift-check.sh"
   },
   "config": {
     "addonName": "Citegeist",

--- a/tools/okf-check.sh
+++ b/tools/okf-check.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# OKF conformance check for Citegeist's docs/ bundle.
+# Open Knowledge Format v0.1 — pinned in docs/STANDARDS.md.
+# Asserts: every non-reserved, non-exempt docs/**/*.md has YAML frontmatter with a
+# non-empty `type`; reserved docs/index.md exists and declares okf_version.
+# Exempt: docs/paper/** (JOSS paper.md has its own required frontmatter contract).
+# Usage: bash tools/okf-check.sh   (exit 0 = conformant, 1 = violations)
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+fail=0
+while IFS= read -r f; do
+  base=$(basename "$f")
+  [ "$base" = "index.md" ] && continue
+  [ "$base" = "log.md" ] && continue
+  if [ "$(head -1 "$f")" != "---" ]; then
+    echo "NO-FRONTMATTER: $f"; fail=1; continue
+  fi
+  awk 'NR>1 && /^---$/{exit} NR>1 && /^type:[[:space:]]*[^[:space:]]/{found=1} END{exit !found}' "$f" \
+    || { echo "NO-TYPE: $f"; fail=1; }
+done < <(find docs -name '*.md' -not -path 'docs/paper/*')
+
+[ -f docs/index.md ] || { echo "MISSING: docs/index.md (OKF reserved catalog)"; fail=1; }
+grep -q 'okf_version' docs/index.md 2>/dev/null || { echo "MISSING: okf_version in docs/index.md"; fail=1; }
+
+if [ "$fail" = 0 ]; then
+  echo "OKF: docs/ bundle conformant (v0.1)"
+else
+  echo "OKF: conformance FAILED — see above"; exit 1
+fi

--- a/tools/okf-drift-check.sh
+++ b/tools/okf-drift-check.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# OKF upstream drift check.
+# Compares the pinned OKF SPEC commit (docs/STANDARDS.md) to the current upstream
+# HEAD of okf/SPEC.md in GoogleCloudPlatform/knowledge-catalog.
+# Exit: 0 = in sync · 3 = DRIFT · 2 = error. Never re-pins automatically.
+set -uo pipefail
+cd "$(dirname "$0")/.."
+
+PINNED=$(grep -i 'Pinned commit' docs/STANDARDS.md | grep -oE '[a-f0-9]{40}' | head -1)
+if [ -z "${PINNED:-}" ]; then
+  echo "ERROR: no pinned commit found in docs/STANDARDS.md"; exit 2
+fi
+
+HEAD=$(gh api 'repos/GoogleCloudPlatform/knowledge-catalog/commits?path=okf/SPEC.md&per_page=1' \
+  --jq '.[0].sha' 2>/dev/null)
+if [ -z "${HEAD:-}" ]; then
+  echo "ERROR: could not fetch upstream HEAD (gh auth / network?)"; exit 2
+fi
+
+if [ "$PINNED" = "$HEAD" ]; then
+  echo "OKF: in sync — pinned ${PINNED:0:12} == upstream HEAD"
+  exit 0
+fi
+
+echo "OKF DRIFT DETECTED"
+echo "  pinned:   $PINNED"
+echo "  upstream: $HEAD"
+echo "  diff:     https://github.com/GoogleCloudPlatform/knowledge-catalog/compare/${PINNED}...${HEAD}"
+echo "  action:   review the okf/SPEC.md diff, update conforming docs, then re-pin in"
+echo "            ~/developer/docs/standards/okf-adoption.md (canonical) + docs/STANDARDS.md."
+exit 3


### PR DESCRIPTION
## What

Adopts the Open Knowledge Format (OKF v0.1, pinned) for Citegeist's `docs/` bundle — the per-product instance of the org-wide OKF standard, mirroring the Split / Trifecta / ME2 reference adoptions.

## Scope — docs only, NOT code

OKF is a markdown + YAML-frontmatter knowledge format — the spec itself states it is *"explicitly not a source-code standard."* It governs `docs/`; it does **not** govern `.ts` syntax (that stays with `tsc` strict + ESLint + Prettier + `src/constants.ts`). "OKF for our coding" = the code's *knowledge* (DESIGN.md, the CLAUDE.md principles) is captured as OKF docs.

Pinned to spec commit `ee67a5c` (v0.1 draft) — re-checked via drift-check, **never** auto-following upstream `main`.

## Changes

- Frontmatter (`type` + title/description/timestamp/tags) on every `docs/**/*.md` (`paper/` exempt — JOSS frontmatter contract)
- `docs/STANDARDS.md` — pinned per-product conformance statement
- `docs/index.md` — reserved OKF bundle catalog (`okf_version`)
- `tools/okf-check.sh` (conformance) + `tools/okf-drift-check.sh` (upstream drift)
- `.github/workflows/okf-watch.yml` — daily drift watch that opens/updates ONE tracking issue when upstream moves; never re-pins. Non-deploy cross-repo automation (no build, ~seconds/day), mirrors ME2's continuous-tracking pattern
- `package.json` scripts `okf:check` / `okf:drift`; `CLAUDE.md` principle + pre-commit checklist

## Verify

```
npm run okf:check     # OKF: docs/ bundle conformant (v0.1)
npm run okf:drift     # OKF: in sync — pinned ee67a5ca2704 == upstream HEAD
npm run format:check  # clean
```

Docs-only behavior; no plugin or build change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
