### PR TITLE
ci(okf): bump okf-watch checkout to v5 (Node 24)

### DIFF
--- a/.github/workflows/okf-watch.yml
+++ b/.github/workflows/okf-watch.yml
@@ -30,7 +30,7 @@ jobs:
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Check OKF upstream drift
         id: drift


### PR DESCRIPTION
Aligns `okf-watch.yml` to the repo's existing `actions/checkout@v5` (ci.yml + release.yml). Clears the Node-20 deprecation warning ahead of GitHub's 2026-06-16 Node-24 default. Workflow-only; no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)