### PR TITLE
ci(badges): self-host shields endpoint badges to end token-pool freeze

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Build & Release
 on:
   push:
     tags:
-      - 'v*'
+      - "v*"
 
 permissions:
   contents: write
@@ -57,3 +57,46 @@ jobs:
               --latest=false \
               --notes "Serves update.json for Zotero's built-in auto-updater. Do not download from here manually — install Citegeist from the latest versioned release."
           gh release upload release build/update.json --clobber
+
+      - name: Refresh self-hosted README badges
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ github.ref_name }}
+        run: |
+          # The README's release + downloads badges are shields *endpoint* badges that
+          # read JSON from the `badges` branch over raw.githubusercontent.com. shields
+          # never calls the GitHub API for them, so the shared-token-pool rate limit
+          # ("Unable to select next GitHub token from pool") that repeatedly froze the
+          # old github/* badges cannot break them. This step regenerates that JSON and
+          # force-pushes it to the orphan `badges` branch on every release.
+          # shields blocks github.com release-asset URLs as endpoint sources, so the
+          # data must live on raw.githubusercontent.com — hence a branch, not a Release.
+          REPO="${{ github.repository }}"
+
+          # Release badge — version is the pushed tag; no API query needed.
+          printf '{"schemaVersion":1,"label":"release","message":"%s","color":"5a9cff"}\n' \
+            "$VERSION" > /tmp/badge-release.json
+
+          # Downloads badge — sum of .xpi downloads across all releases (real installs).
+          # Excludes update.json, which Zotero's auto-updater polls on a schedule and
+          # would otherwise inflate the count (~2x as of v2.0.4).
+          DL=$(gh api "repos/$REPO/releases" --paginate \
+            --jq '[.[].assets[] | select(.name | endswith(".xpi")) | .download_count] | add // 0')
+          MSG=$(node -e "const n=+process.argv[1];process.stdout.write(n>=1e6?(n/1e6).toFixed(1)+'M':n>=1e3?(n/1e3).toFixed(1)+'k':String(n))" "$DL")
+          printf '{"schemaVersion":1,"label":"downloads","message":"%s","color":"30d158"}\n' \
+            "$MSG" > /tmp/badge-downloads.json
+
+          # Publish to an orphan `badges` branch via a throwaway worktree, so the JSON
+          # never touches main and the branch never accumulates history (force-push a
+          # fresh root commit each release).
+          git worktree add --detach /tmp/cg-badges HEAD
+          cd /tmp/cg-badges
+          git checkout --orphan badges-tmp
+          git rm -rf . --quiet
+          cp /tmp/badge-release.json badge-release.json
+          cp /tmp/badge-downloads.json badge-downloads.json
+          git add badge-release.json badge-downloads.json
+          git -c user.name="github-actions[bot]" \
+              -c user.email="41898282+github-actions[bot]@users.noreply.github.com" \
+              commit --quiet -m "chore(badges): refresh for ${VERSION}"
+          git push --force origin badges-tmp:badges

--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@
 </p>
 
 <p align="center">
-  <a href="https://github.com/phdemotions/zotero-citegeist/releases/latest"><img alt="Latest release" src="https://img.shields.io/github/v/release/phdemotions/zotero-citegeist?style=flat-square&color=5a9cff" /></a>
-  <a href="https://github.com/phdemotions/zotero-citegeist/releases/latest"><img alt="Downloads" src="https://img.shields.io/github/downloads/phdemotions/zotero-citegeist/total?style=flat-square&color=30d158" /></a>
+  <a href="https://github.com/phdemotions/zotero-citegeist/releases/latest"><img alt="Latest release" src="https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/phdemotions/zotero-citegeist/badges/badge-release.json&style=flat-square" /></a>
+  <a href="https://github.com/phdemotions/zotero-citegeist/releases/latest"><img alt="Downloads" src="https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/phdemotions/zotero-citegeist/badges/badge-downloads.json&style=flat-square" /></a>
   <a href="https://github.com/phdemotions/zotero-citegeist/blob/main/LICENSE"><img alt="License: GPL-3.0-or-later" src="https://img.shields.io/badge/license-GPL--3.0-8e8e93?style=flat-square" /></a>
   <a href="https://doi.org/10.5281/zenodo.19433716"><img alt="DOI" src="https://zenodo.org/badge/DOI/10.5281/zenodo.19433716.svg" /></a>
 </p>


### PR DESCRIPTION
## Problem

The **release** and **downloads** README badges have repeatedly broken — rendering `Unable to select next GitHub token from pool` instead of a value (see screenshot in the issue that prompted this).

Root cause is **not** a missing release. `v2.0.4` is tagged, released, and `Latest`; the floating `release` auto-update channel is intact. The badges used shields' `github/v/release` + `github/downloads/total` routes, which query the GitHub API through **shields' shared token pool**. When that pool is rate-limited, shields bakes the error text into the badge SVG and GitHub's camo image proxy caches the broken render — so it stays frozen. It has recurred multiple times; `cacheSeconds` only delays it.

## Fix — remove the GitHub-API dependency entirely

Both badges become shields **endpoint** badges that read JSON from a dedicated orphan **`badges`** branch over `raw.githubusercontent.com`. shields never calls the GitHub API for these → the token-pool limit **cannot** break them again.

- **`README.md`** — both badges → `img.shields.io/endpoint?url=…/badges/badge-*.json`
- **`.github/workflows/release.yml`** — new step regenerates `badge-release.json` + `badge-downloads.json` and force-pushes them to `badges` on every release (self-maintaining, mirrors the existing `update.json` auto-update plumbing)
- **`badges` branch** — already seeded, so the live badges resolve the moment this merges

shields blocks `github.com` release-asset URLs as endpoint sources (verified: `custom badge: domain is blocked`), so the data must live on `raw.githubusercontent.com` — hence a branch, not a Release asset.

### Semantic change (intentional, visible)

Downloads now counts **`.xpi` assets only** (real installs) instead of all assets:

| | old badge | new badge |
|---|---|---|
| count | **1134** | **688** |

The old `total` was inflated ~2× by Zotero's auto-updater polling `update.json` (429 of those 1134 were `release/update.json` fetches). 688 is the honest install count.

## Verification

- `raw.githubusercontent.com/.../badges/badge-release.json` → shields renders `release: v2.0.4` ✅
- `…/badge-downloads.json` → shields renders `downloads: 688` ✅
- `release.yml` valid YAML, Prettier-clean
- Workflow badge-generation logic dry-run locally (jq + node humanize → valid JSON)

🤖 Generated with [Claude Code](https://claude.com/claude-code)