### PR TITLE
fix(menu): repair MenuManager labels + registration lifecycle (#67)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.5] — 2026-07-09
+
+### Fixed
+
+- **The right-click menu could show blank entries and then stop responding.** On
+  Zotero 8 and 9, Citegeist's right-click menu items could appear with no visible
+  label (though they still worked), and after using one, the right-click menu
+  could stop opening on any item until the plugin was disabled and re-enabled.
+  Both problems are fixed: the menu labels now render, and Citegeist registers its
+  menu exactly once per session no matter how many library windows you open or
+  close. Thanks to the people who reported issue #67.
+
 ### Internal
 
 - Project documentation adopts the Open Knowledge Format (OKF v0.1, pinned): every
@@ -476,6 +488,7 @@ network browser got a thorough pass alongside it:
 - CI pipeline with build, typecheck, and test stages
 - JOSS paper, DESIGN.md, CONTRIBUTING.md, CODE_OF_CONDUCT.md
 
+[2.0.5]: https://github.com/phdemotions/zotero-citegeist/compare/v2.0.4...v2.0.5
 [2.0.4]: https://github.com/phdemotions/zotero-citegeist/compare/v2.0.3...v2.0.4
 [2.0.3]: https://github.com/phdemotions/zotero-citegeist/compare/v2.0.2...v2.0.3
 [2.0.2]: https://github.com/phdemotions/zotero-citegeist/compare/v2.0.1...v2.0.2

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: "If you use this software, please cite it as below."
 type: software
 title: "Citegeist: Real-Time Citation Intelligence for Business and Management Research"
-version: 2.0.4
-date-released: "2026-06-10"
+version: 2.0.5
+date-released: "2026-07-09"
 license: GPL-3.0-or-later
 url: "https://github.com/phdemotions/zotero-citegeist"
 repository-code: "https://github.com/phdemotions/zotero-citegeist"

--- a/addon/locale/en-US/citegeist.ftl
+++ b/addon/locale/en-US/citegeist.ftl
@@ -5,9 +5,20 @@ citegeist-pane-refresh =
 citegeist-pane-settings =
     .title = Citegeist settings
 
-# Context-menu labels (Zotero 8+ MenuManager path; the DOM fallback on
-# Zotero 7.0.x sets these strings directly via setAttribute).
-citegeist-menu-fetch = Fetch Citation Counts
-citegeist-menu-citing = View Citing Works…
-citegeist-menu-refs = View References…
-citegeist-menu-fetch-collection = Fetch All Citation Counts (Citegeist)
+# Context-menu labels (Zotero 8+ MenuManager path). MenuManager applies these
+# via `dataset.l10nId` on a XUL <menuitem>, so they MUST use Fluent attribute
+# syntax (.label / .accesskey). A bare `id = value` message has no text node to
+# land in on a menuitem and renders blank — the cause of issue #67. Accesskeys
+# mirror the DOM fallback path's audited mnemonics (item menu: G is free;
+# collection menu: I is free). The DOM fallback on Zotero 7.0.x sets its own
+# labels via setAttribute and never reads these messages.
+citegeist-menu-fetch =
+    .label = Fetch Citation Counts
+    .accesskey = G
+citegeist-menu-citing =
+    .label = View Citing Works…
+citegeist-menu-refs =
+    .label = View References…
+citegeist-menu-fetch-collection =
+    .label = Fetch All Citation Counts (Citegeist)
+    .accesskey = I

--- a/docs/plans/2026-07-06-001-fix-menu-manager-registration-lifecycle-plan.md
+++ b/docs/plans/2026-07-06-001-fix-menu-manager-registration-lifecycle-plan.md
@@ -1,0 +1,155 @@
+---
+title: "fix: Repair Zotero MenuManager context-menu registration lifecycle"
+type: fix
+date: 2026-07-06
+---
+
+# fix: Repair Zotero MenuManager context-menu registration lifecycle
+
+## Summary
+
+Two independent bugs behind Zotero 8/9's `MenuManager` context-menu path, both root-caused directly against Zotero core's own source: context-menu labels render blank, and the registration entry point mishandles being called more than once per process, which can leave a duplicate DOM menu layered on top of the live MenuManager one, or silently kill the menu in every other open window. Fix is confined to `src/modules/menu.ts`, `addon/locale/en-US/citegeist.ftl`, and `src/hooks.ts`.
+
+## Problem Frame
+
+[GitHub issue #67](https://github.com/phdemotions/zotero-citegeist/issues/67) (two independent reporters, Zotero 9.0.5 / Windows, v2.0.4): right-clicking an item shows Citegeist's menu entries with no visible label text (though they're still clickable), and after using one once, right-click stops responding anywhere in Zotero until the plugin is disabled and re-enabled.
+
+Both root causes were confirmed by reading Zotero's actual core source (`zotero/zotero` at commit `55eceab`), not assumed:
+
+- **Blank labels.** `addon/locale/en-US/citegeist.ftl` defines the four menu strings as bare Fluent messages (`citegeist-menu-fetch = Fetch Citation Counts`). Zotero's `MenuManager` (`chrome/content/zotero/xpcom/pluginAPI/menuManager.js:453-454`) sets `menuElem.dataset.l10nId` on a XUL `<menuitem>`. Fluent's DOM overlay only fills the `label`/`accesskey` **attributes** of a menuitem via the `.label =` attribute syntax — a menuitem has no text-node child for a bare `.value` translation to land in, so it renders empty. `citegeist-pane-refresh` and `citegeist-pane-settings`, two lines above the broken entries in the same file, already use the correct `.title` attribute form for their own tooltip text — the fix is applying that same already-proven pattern to the menu labels.
+- **Right-click death.** `src/modules/menu.ts:470-485` (`registerMenus`) treats any `false` return from `Zotero.MenuManager.registerMenu()` as "MenuManager unavailable, fall back to DOM." But `pluginAPIBase.mjs:177-194` (Zotero core) rejects with `false` for one specific, indistinguishable-from-outside reason relevant here: the `menuID` is a **process-global** registry key, already registered. `registerMenus(win)` legitimately runs more than once per process — a second Zotero library window via File → New Window fires `onMainWindowLoad` again (`chrome/content/zotero/xpcom/plugins.js:93-110`) — and each re-invocation currently misreads the resulting "duplicate" rejection as failure, permanently injecting a second, uncoordinated DOM menu system onto the same popup that MenuManager is still actively managing. This dual-registration state is confirmed wrong regardless of the exact freeze mechanism — Zotero's own API contract treats the menuID as a singleton, and nothing in the plugin should inject a second competing system once one is active. The specific causal link from that dual state to "right-click permanently dead" is this plan's best-evidenced working hypothesis from static source analysis, not a traced runtime stack; the manual QA pass below (step 3) is where it gets empirically confirmed. Disable/re-enable is the only existing path that tears both systems down and resets the global registry, incidentally "fixing" it — consistent with the dual-registration theory either way.
+
+A third, related defect was found verifying the teardown side of the same code during planning: `unregisterMenus(win)` is called from `onMainWindowUnload` on **every** window close, but it unconditionally tears down the same process-global MenuManager registration — so closing one secondary Zotero window silently removes Citegeist's context menu from every other window still open, for the rest of the session. This is the same "MenuManager registration treated as per-window" misconception as the main bug, just on the unregister side; fixing the registration guard without also fixing this leaves the underlying defect class half-fixed.
+
+## Requirements
+
+- R1. Context-menu entries (Fetch Citation Counts, View Citing Works, View References, Fetch All Citation Counts) render their configured label text on the MenuManager path (Zotero 8+).
+- R2. Calling the menu-registration entry point more than once in a single process lifetime does not inject a second, DOM-based copy of the menu items alongside an active MenuManager registration.
+- R3. Closing one Zotero library window does not remove Citegeist's context-menu entries from other windows that remain open.
+- R4. The existing behavior for a genuine single-call MenuManager rejection (roll back what succeeded, fall back to DOM) is unchanged.
+
+## Key Technical Decisions
+
+- **Fix labels via Fluent `.label`/`.accesskey` attributes, not textContent.** `menuitem` is attribute-only per Fluent's XUL overlay allow-list (confirmed against Zotero's own `menuManager.js`, which sets `dataset.l10nId` on a bare `<menuitem>` with no text-node child). This exactly mirrors the `.title` pattern already correctly used by `citegeist-pane-refresh`/`citegeist-pane-settings` two lines above in the same file — no new pattern introduced.
+- **Idempotency is a local module flag, not a parsed rejection reason.** Zotero's `registerMenu` returns bare `false` for "duplicate" and "genuinely invalid" alike, with no reason string exposed (confirmed in `pluginAPIBase.mjs:_validate`). The only reliable way to distinguish "already active" from "rejected" is tracking our own prior success, mirroring the existing `registered` boolean guard in `src/modules/citationColumn.ts` (`registerCitationColumn`/`unregisterCitationColumn`) rather than inventing a new pattern.
+- **Split teardown into per-window (DOM-only) and global (MenuManager) responsibilities.** MenuManager registration is process-global; window close events are per-window. Conflating the two is what causes R3's defect. `unregisterMenus(win)` keeps its existing DOM-node cleanup (still correct and needed for Zotero 7.0.x windows); a new `unregisterGlobalMenus()` owns the MenuManager teardown and only runs from plugin shutdown.
+- **No new accesskeys invented.** The DOM fallback path deliberately gives View Citing/References no accesskey ("infrequent; Tab + Enter works"). The MenuManager path's `.accesskey` additions (Fetch → `G`, Fetch All → `I`) mirror the DOM path's existing mnemonics exactly rather than adding new ones.
+
+## High-Level Technical Design
+
+Registration/teardown across two windows and shutdown, before and after:
+
+```mermaid
+sequenceDiagram
+    participant WinA as Window A
+    participant WinB as Window B (File > New Window)
+    participant Menu as menu.ts state
+    participant MM as Zotero.MenuManager (global)
+
+    Note over Menu: menuManagerRegistered = false
+    WinA->>Menu: registerMenus(winA)
+    Menu->>MM: registerMenu(item), registerMenu(collection)
+    MM-->>Menu: true, true
+    Note over Menu: menuManagerRegistered = true
+    WinB->>Menu: registerMenus(winB)
+    Note over Menu: guard: already true -- return, no re-attempt, no DOM fallback
+    WinB->>Menu: (user closes Window B)
+    Menu->>Menu: unregisterMenus(winB) -- per-window DOM cleanup only
+    Note over MM: untouched -- WinA's menu still active
+    Note over Menu: (shutdown) unregisterGlobalMenus()
+    Menu->>MM: unregisterMenu(item), unregisterMenu(collection)
+    Note over Menu: menuManagerRegistered = false
+```
+
+## Scope Boundaries
+
+- **Checked, confirmed unaffected:** `citegeist-pane-header`/`citegeist-pane-sidenav` use the same bare-value FTL syntax but render into an `ItemPaneManager` header/sidenav slot, not a XUL `menuitem` — a different target element type. This text has shipped and rendered correctly since v2.0.0 with no reports of blank text, unlike the two independent reports specific to the context menu. No change.
+- **Checked, already correct:** `citegeist-pane-refresh`/`citegeist-pane-settings` already use `.title` attribute syntax — used as the precedent pattern for this fix, not touched.
+- **Out of scope:** `registerViaDOM`'s own element-creation logic (the Zotero-7.0.x-only path) is unchanged — only the guard deciding whether it runs is touched.
+
+## Implementation Units
+
+### U1. Fix Fluent attribute syntax for context-menu labels
+
+**Goal:** Menu item labels render their configured text on the MenuManager path.
+**Requirements:** R1
+**Dependencies:** none
+**Files:** `addon/locale/en-US/citegeist.ftl`, `test/menu.test.ts`
+**Approach:** Rewrite the four `citegeist-menu-*` entries from bare-value to `.label` attribute form; add `.accesskey` to `citegeist-menu-fetch` (`G`) and `citegeist-menu-fetch-collection` (`I`) only, matching the DOM path's existing mnemonics. Leave `citegeist-menu-citing`/`citegeist-menu-refs` without an accesskey, matching the DOM path's deliberate omission.
+**Patterns to follow:** `citegeist-pane-refresh`/`citegeist-pane-settings` in the same file — already-correct `.title` attribute form.
+**Test scenarios:**
+- Static: every `citegeist-menu-*` message in `citegeist.ftl` defines a `.label` sub-attribute (file-content regex assertion, mirroring the raw-hex-regex guard in `test/ui-primitives.test.ts`).
+- Static: `citegeist-menu-fetch` and `citegeist-menu-fetch-collection` also define `.accesskey`; `citegeist-menu-citing`/`citegeist-menu-refs` deliberately do not.
+**Verification:** New test passes; visible label text confirmed in the manual QA pass below.
+
+### U2. Idempotent MenuManager registration guard
+
+**Goal:** A second call to `registerMenus` is a no-op once MenuManager is already active — no re-attempt, no DOM fallback.
+**Requirements:** R2, R4
+**Dependencies:** none
+**Files:** `src/modules/menu.ts`, `test/menu.test.ts`
+**Approach:** Add module-level `let menuManagerRegistered = false;` alongside the existing `menuPluginID` state. `registerMenus` returns immediately if the flag is already `true`. Set it `true` only when `registerViaMenuManager` returns `true` (full success for both menus). The existing attempt/rollback/DOM-fallback logic for a genuine single-call rejection is untouched — it only runs while the flag is still `false`.
+**Technical design (directional):**
+```
+registerMenus(win):
+  if menuManagerRegistered: return        # new — short-circuits re-attempt AND DOM fallback
+  ...existing mm-present branch...
+  if registerViaMenuManager(...) succeeds:
+    menuManagerRegistered = true; return
+  ...existing DOM fallback, unchanged...
+```
+**Patterns to follow:** The `registered` boolean guard in `src/modules/citationColumn.ts` (`registerCitationColumn`/`unregisterCitationColumn`) — same shape, flag set on success, reset on teardown.
+**Test scenarios:**
+- Calling `registerMenus(win)` twice in sequence (MenuManager present, mock succeeds both times) results in `registerMenu` invoked exactly twice total, both on the first call — the second call must not invoke it again.
+- After two calls, no DOM nodes were injected (`doc.getElementById(MENU_IDS.fetchCitations)` stays `null`).
+- The existing "rolls back the item menu and falls back to DOM when the collection registration is rejected" scenario (`test/menu.test.ts:199`) still passes unmodified — a genuine single-call partial failure is unaffected by the new guard.
+- Calling `registerMenus` with a second, distinct `win` object after a successful first-window registration is also a no-op — proves the guard is process-global, not per-window.
+**Verification:** New and existing tests green; `npm run typecheck`.
+
+### U3. Correct global-vs-per-window teardown
+
+**Goal:** Closing one window never removes the MenuManager registration other open windows still depend on.
+**Requirements:** R3
+**Dependencies:** U2 (shares `menuManagerRegistered`)
+**Files:** `src/modules/menu.ts`, `src/hooks.ts`, `test/menu.test.ts`
+**Approach:** Keep `unregisterMenus(win)` as pure per-window DOM cleanup (its existing DOM-node-removal loop — still needed for Zotero 7.0.x windows and to mop up stray fallback nodes). Add `unregisterGlobalMenus()` (no `win` parameter): calls `mm.unregisterMenu` for both menu IDs and resets `menuManagerRegistered = false`. In `src/hooks.ts`, `onMainWindowUnload` keeps calling only `unregisterMenus(win)`. `onShutdown` calls `unregisterGlobalMenus()` **unconditionally**, alongside (not nested inside) its existing `if (win) unregisterMenus(win);` guard — global MenuManager teardown must not depend on whether `Zotero.getMainWindow()` returned a window, since the registration it's undoing was never window-scoped to begin with.
+**Patterns to follow:** The existing `onShutdown` error-wrapping style in `src/hooks.ts` (try/catch + `logError` per cleanup call).
+**Test scenarios:**
+- Calling `unregisterMenus(win)` alone (simulating one window closing) does not call `mm.unregisterMenu` — the global registration stays intact.
+- Calling `unregisterGlobalMenus()` calls `mm.unregisterMenu` for both `citegeist-item-menu` and `citegeist-collection-menu` and resets the idempotency flag, so a subsequent `registerMenus` call re-attempts rather than no-ops.
+- Integration-shaped: register → `unregisterMenus(winB)` (window B closes) → `registerMenus(winB)` again must still be a no-op (globally, still registered) — proves U2's flag survives a per-window-only teardown.
+- The existing "unregisters both MenuManager menus on teardown" scenario (`test/menu.test.ts:211-218`) currently asserts that `unregisterMenus(win)` alone triggers both `mm.unregisterMenu` calls — the direct opposite of this unit's split. Rewrite that scenario to call `unregisterGlobalMenus()` instead of `unregisterMenus(win)` so its assertion matches the new division of responsibility.
+**Verification:** New and updated tests green; manual QA step below (close secondary window, menu persists in primary).
+
+### U4. Changelog entry
+
+**Goal:** Document the fix for release notes and issue closure.
+**Requirements:** R1, R2, R3
+**Dependencies:** U1, U2, U3
+**Files:** `CHANGELOG.md`
+**Approach:** Add a `### Fixed` bullet under `[Unreleased]` in the existing bold-summary-then-prose style, describing the invisible-label and right-click-death fix in user-facing language and crediting issue #67.
+**Test expectation:** none -- pure documentation, no behavior to test.
+**Verification:** Entry reads naturally alongside the existing `[Unreleased]` structure.
+
+## Risks & Dependencies
+
+- Manual QA (below) requires a real multi-window Zotero 9.x session — vitest cannot observe live popup/window behavior, so this is the only verification for R2/R3's actual user-visible fix, not just the mocked registration-count assertions.
+- Low overall risk: the fix is confined to one module's registration/teardown guards plus a locale file, follows an already-established local pattern (`citationColumn.ts`), and the existing test suite's partial-failure scenario is preserved unmodified (verified during planning, not just assumed).
+
+## Sources / Research
+
+- `chrome/content/zotero/xpcom/pluginAPI/menuManager.js:453-454` (Zotero core, commit `55eceab`) — confirms `l10nID` is applied via `dataset.l10nId` on a bare `<menuitem>`, which requires Fluent's attribute syntax to render.
+- `chrome/content/zotero/xpcom/pluginAPI/pluginAPIBase.mjs:177-194` — confirms `registerMenu`'s `false` return is a generic "rejected" signal (duplicate mainKey or failed validation) with no reason exposed.
+- `chrome/content/zotero/xpcom/plugins.js:93-110` — confirms `onMainWindowLoad` fires per newly opened window via `Services.wm`'s `onOpenWindow` listener, independent of `onStartup`.
+- `src/modules/citationColumn.ts:53-54, 216-242, 493-518` — the existing `registered` module-flag pattern this fix mirrors.
+
+## Documentation / Operational Notes
+
+Manual QA on real Zotero 9.x (this bug is specifically about live popup/window interaction vitest cannot observe):
+
+1. `npm run build:dev`, install the proxy build, restart Zotero.
+2. Right-click an item in the main library window — confirm all four Citegeist entries show visible label text (not blank).
+3. Run "Fetch Citation Counts" once. Right-click several more items in a row — confirm the context menu keeps opening every time (the reported failure mode).
+4. File → New Window to open a second library window. Right-click items in both windows — confirm labels render in both, no duplicated/garbled entries in either.
+5. Close the second window. Right-click in the first (remaining) window — confirm Citegeist's entries are still present and functional.
+6. Disable and re-enable the plugin (the previous workaround) — confirm it still works cleanly afterward, as a regression safety net.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zotero-citegeist",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zotero-citegeist",
-      "version": "2.0.4",
+      "version": "2.0.5",
       "license": "GPL-3.0-or-later",
       "devDependencies": {
         "@eslint/js": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zotero-citegeist",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "description": "Citation intelligence for Zotero — powered by OpenAlex. See citation counts, explore citation networks, and add citing/cited works to your library.",
   "homepage": "https://github.com/phdemotions/zotero-citegeist",
   "author": "Josh Gonzales",

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -5,7 +5,12 @@
 
 import { registerCitationColumn, unregisterCitationColumn } from "./modules/citationColumn";
 import { registerCitationPane, unregisterCitationPane } from "./modules/citationPane";
-import { registerMenus, unregisterMenus, setMenuPluginID } from "./modules/menu";
+import {
+  registerMenus,
+  unregisterMenus,
+  unregisterGlobalMenus,
+  setMenuPluginID,
+} from "./modules/menu";
 import { clearSourceStatsCache } from "./modules/openalex";
 import { initCache, closeCache, migrateFromExtraV1, garbageCollectOrphans } from "./modules/cache";
 import { logError } from "./modules/utils";
@@ -177,6 +182,14 @@ export async function onShutdown(_data: PluginData): Promise<void> {
     if (win) unregisterMenus(win);
   } catch (e) {
     logError("shutdown unregisterMenus", e);
+  }
+  // Global MenuManager teardown is process-scoped, not window-scoped: run it
+  // unconditionally, independent of whether getMainWindow() returned a window.
+  // (unregisterMenus above only clears per-window DOM nodes.)
+  try {
+    unregisterGlobalMenus();
+  } catch (e) {
+    logError("shutdown unregisterGlobalMenus", e);
   }
   try {
     unregisterCitationColumn();

--- a/src/modules/menu.ts
+++ b/src/modules/menu.ts
@@ -82,6 +82,23 @@ export function setMenuPluginID(id: string): void {
   menuPluginID = id;
 }
 
+/**
+ * True once the process-global MenuManager registration has fully succeeded.
+ *
+ * The MenuManager registry is keyed per-process, not per-window, so a second
+ * `registerMenus` call — File > New Window fires `onMainWindowLoad` again, and
+ * dev hot-reload can re-enter — must be a NO-OP. Without this guard the repeat
+ * call re-attempts `registerMenu`, Zotero rejects it as a duplicate (a plain
+ * `false`, indistinguishable from a real failure), and the old code misread
+ * that as "MenuManager unavailable" and injected a second, uncoordinated DOM
+ * menu onto the same popup MenuManager still owns — the root cause of the
+ * garbled / dead right-click menu in issue #67.
+ *
+ * Mirrors the `registered` flag in `citationColumn.ts`. Reset only by
+ * `unregisterGlobalMenus()` at plugin shutdown.
+ */
+let menuManagerRegistered = false;
+
 function getMenuManager(): ZoteroMenuManager | null {
   const mm = (Zotero as unknown as { MenuManager?: ZoteroMenuManager }).MenuManager;
   return mm && typeof mm.registerMenu === "function" ? mm : null;
@@ -468,10 +485,20 @@ function registerViaDOM(win: Window): void {
 // ── Public API ───────────────────────────────────────────────────────────────
 
 export function registerMenus(win: Window): void {
+  // Idempotency guard (issue #67): the MenuManager registration is
+  // process-global, so once it is active a repeat call (new window, hot-reload)
+  // must do nothing. Re-attempting would be rejected as a duplicate and misread
+  // as "MenuManager broken", injecting a duplicate DOM menu onto the same popup.
+  if (menuManagerRegistered) {
+    Zotero.debug("[Citegeist] Menus already registered (MenuManager) — skipping");
+    return;
+  }
+
   const mm = getMenuManager();
   if (mm && menuPluginID) {
     try {
       if (registerViaMenuManager(mm, menuPluginID)) {
+        menuManagerRegistered = true;
         Zotero.debug("[Citegeist] Menus registered (MenuManager)");
         return;
       }
@@ -484,9 +511,31 @@ export function registerMenus(win: Window): void {
   registerViaDOM(win);
 }
 
+/**
+ * Per-window teardown. Removes any DOM-injected menu nodes from THIS window
+ * only. Runs on every window unload.
+ *
+ * Deliberately does NOT touch the process-global MenuManager registration:
+ * doing so would remove Citegeist's context menu from every other still-open
+ * window (issue #67, teardown side — a secondary window closing silently killed
+ * the menu everywhere). Global MenuManager teardown lives in
+ * `unregisterGlobalMenus()` and runs once, at plugin shutdown.
+ */
 export function unregisterMenus(win: Window): void {
-  // MenuManager menus auto-clean on plugin shutdown via pluginID, but tear them
-  // down explicitly too so a window-unload or hot-reload leaves nothing behind.
+  const doc = win.document;
+  for (const id of Object.values(MENU_IDS)) {
+    doc.getElementById(id)?.remove();
+  }
+}
+
+/**
+ * Process-global teardown. Unregisters the MenuManager menus and resets the
+ * idempotency flag. Call ONCE, at plugin shutdown — never on a per-window
+ * unload. MenuManager menus also auto-clean on plugin shutdown via `pluginID`,
+ * but tearing them down explicitly keeps a hot-reload from leaking a stale
+ * registration behind the flag.
+ */
+export function unregisterGlobalMenus(): void {
   const mm = getMenuManager();
   if (mm) {
     for (const id of [MM_ITEM_MENU_ID, MM_COLLECTION_MENU_ID]) {
@@ -497,9 +546,5 @@ export function unregisterMenus(win: Window): void {
       }
     }
   }
-  // Always remove any DOM nodes too (covers the fallback path + mixed states).
-  const doc = win.document;
-  for (const id of Object.values(MENU_IDS)) {
-    doc.getElementById(id)?.remove();
-  }
+  menuManagerRegistered = false;
 }

--- a/test/menu.test.ts
+++ b/test/menu.test.ts
@@ -2,10 +2,15 @@
  * Tests for the Zotero 8+ `Zotero.MenuManager` registration path and its
  * fallback to the DOM path (Zotero 7.0.x). The DOM handler behaviour itself is
  * covered by collection-menu.test.ts.
+ *
+ * `menu.ts` holds process-global module state (`menuManagerRegistered`), so
+ * each test loads a fresh module instance via `loadMenu()` (vi.resetModules +
+ * dynamic import) — the same pattern citationColumn.test.ts uses for its own
+ * `registered` flag. Without it, the flag would leak across tests.
  */
 
+import { readFileSync } from "node:fs";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { registerMenus, unregisterMenus, setMenuPluginID } from "../src/modules/menu";
 import { FakeDocument, makeItem, flushAsync } from "./_helpers/menuHarness";
 
 const mocks = vi.hoisted(() => ({
@@ -86,20 +91,32 @@ function installZotero(withMenuManager: boolean): void {
   vi.stubGlobal("Services", { prompt: { alert: vi.fn() } });
 }
 
+/**
+ * Fresh `menu.ts` instance per call so the module-global
+ * `menuManagerRegistered` flag never leaks between tests. Mirrors
+ * citationColumn.test.ts's `loadCitationColumn()`.
+ */
+async function loadMenu() {
+  vi.resetModules();
+  const mod = await import("../src/modules/menu");
+  mod.setMenuPluginID(PLUGIN_ID);
+  return mod;
+}
+
 beforeEach(() => {
   vi.clearAllMocks();
   doc = new FakeDocument();
   win = { document: doc } as unknown as Window;
   selectedItems = [makeItem(1)];
   registerReturns = [];
-  setMenuPluginID(PLUGIN_ID);
 });
 
 const findMenu = (target: string) => captured.find((c) => c.target === target)!;
 
 describe("MenuManager path (Zotero 8+)", () => {
-  it("registers item + collection menus via MenuManager, not the DOM", () => {
+  it("registers item + collection menus via MenuManager, not the DOM", async () => {
     installZotero(true);
+    const { registerMenus } = await loadMenu();
     registerMenus(win);
 
     expect(registerMenu).toHaveBeenCalledTimes(2);
@@ -118,8 +135,9 @@ describe("MenuManager path (Zotero 8+)", () => {
     expect(doc.getElementById("citegeist-menu-fetch")).toBeNull();
   });
 
-  it("decides item-menu visibility from context.items in onShowing", () => {
+  it("decides item-menu visibility from context.items in onShowing", async () => {
     installZotero(true);
+    const { registerMenus } = await loadMenu();
     registerMenus(win);
     const item = findMenu("main/library/item");
 
@@ -154,8 +172,9 @@ describe("MenuManager path (Zotero 8+)", () => {
     expect(visCiting1).toHaveBeenCalledWith(true);
   });
 
-  it("gates View Citing/References on canResolveWork, not mere single-selection", () => {
+  it("gates View Citing/References on canResolveWork, not mere single-selection", async () => {
     installZotero(true);
+    const { registerMenus } = await loadMenu();
     registerMenus(win);
     const item = findMenu("main/library/item");
     const citingShowing = item.menus[1].onShowing!;
@@ -174,8 +193,9 @@ describe("MenuManager path (Zotero 8+)", () => {
     expect(visNonResolvable).toHaveBeenCalledWith(false);
   });
 
-  it("runs the View Citing action from onCommand", () => {
+  it("runs the View Citing action from onCommand", async () => {
     installZotero(true);
+    const { registerMenus } = await loadMenu();
     registerMenus(win);
     const item = findMenu("main/library/item");
     selectedItems = [makeItem(7)];
@@ -188,6 +208,7 @@ describe("MenuManager path (Zotero 8+)", () => {
 
   it("runs the collection fetch action from onCommand", async () => {
     installZotero(true);
+    const { registerMenus } = await loadMenu();
     registerMenus(win);
     const collection = findMenu("main/library/collection");
     selectedItems = [makeItem(1), makeItem(2)];
@@ -196,8 +217,9 @@ describe("MenuManager path (Zotero 8+)", () => {
     expect(mocks.fetchAndCacheItems).toHaveBeenCalled();
   });
 
-  it("rolls back the item menu and falls back to DOM when the collection registration is rejected", () => {
+  it("rolls back the item menu and falls back to DOM when the collection registration is rejected", async () => {
     installZotero(true);
+    const { registerMenus } = await loadMenu();
     registerReturns = ["citegeist-item-menu", false]; // item ok, collection rejected
     registerMenus(win);
 
@@ -207,23 +229,121 @@ describe("MenuManager path (Zotero 8+)", () => {
     expect(doc.getElementById("citegeist-menu-fetch")).not.toBeNull();
     expect(doc.getElementById("citegeist-menu-fetch-collection")).not.toBeNull();
   });
+});
 
-  it("unregisters both MenuManager menus on teardown", () => {
+describe("registration is idempotent across repeat calls (issue #67)", () => {
+  it("a second registerMenus call does not re-register or fall back to DOM", async () => {
     installZotero(true);
+    const { registerMenus } = await loadMenu();
     registerMenus(win);
-    unregisterMenus(win);
+    registerMenus(win); // File > New Window / hot-reload re-entry
+
+    // registerMenu fired only on the first call (2 menus), never again.
+    expect(registerMenu).toHaveBeenCalledTimes(2);
+    // The repeat call injected no DOM fallback nodes.
+    expect(doc.getElementById("citegeist-menu-fetch")).toBeNull();
+    expect(doc.getElementById("citegeist-menu-fetch-collection")).toBeNull();
+  });
+
+  it("stays a no-op for a second, distinct window — the guard is process-global", async () => {
+    installZotero(true);
+    const { registerMenus } = await loadMenu();
+    registerMenus(win);
+
+    const doc2 = new FakeDocument();
+    const win2 = { document: doc2 } as unknown as Window;
+    registerMenus(win2);
+
+    expect(registerMenu).toHaveBeenCalledTimes(2);
+    expect(doc2.getElementById("citegeist-menu-fetch")).toBeNull();
+  });
+});
+
+describe("global-vs-per-window teardown (issue #67)", () => {
+  it("unregisterMenus removes only DOM nodes, leaving the MenuManager registration intact", async () => {
+    installZotero(true);
+    const { registerMenus, unregisterMenus } = await loadMenu();
+    registerMenus(win);
+    unregisterMenus(win); // one window closing
+
+    // The process-global MenuManager registration must survive — other open
+    // windows still depend on it.
+    expect(unregisterMenu).not.toHaveBeenCalled();
+  });
+
+  it("unregisterGlobalMenus tears down both MenuManager menus and resets the guard", async () => {
+    installZotero(true);
+    const { registerMenus, unregisterGlobalMenus } = await loadMenu();
+    registerMenus(win);
+    unregisterGlobalMenus();
+
     const ids = unregisterMenu.mock.calls.map((c) => c[0]);
     expect(ids).toContain("citegeist-item-menu");
     expect(ids).toContain("citegeist-collection-menu");
+
+    // Flag reset: a subsequent registerMenus re-attempts registration.
+    registerMenus(win);
+    expect(registerMenu).toHaveBeenCalledTimes(4); // 2 initial + 2 after reset
+  });
+
+  it("a per-window unload does not let a later registerMenus re-register", async () => {
+    installZotero(true);
+    const { registerMenus, unregisterMenus } = await loadMenu();
+    registerMenus(win);
+    unregisterMenus(win); // window B closes — DOM-only teardown
+    registerMenus(win); // a window re-registers
+
+    // Still globally registered, so no second MenuManager attempt.
+    expect(registerMenu).toHaveBeenCalledTimes(2);
   });
 });
 
 describe("DOM fallback (Zotero 7.0.x, no MenuManager)", () => {
-  it("registers menus via the DOM when Zotero.MenuManager is absent", () => {
+  it("registers menus via the DOM when Zotero.MenuManager is absent", async () => {
     installZotero(false);
+    const { registerMenus } = await loadMenu();
     registerMenus(win);
     expect(doc.getElementById("citegeist-menu-fetch")).not.toBeNull();
     expect(doc.getElementById("citegeist-menu-citing")).not.toBeNull();
     expect(doc.getElementById("citegeist-menu-fetch-collection")).not.toBeNull();
+  });
+});
+
+describe("context-menu FTL uses attribute syntax (issue #67)", () => {
+  const ftl = readFileSync(new URL("../addon/locale/en-US/citegeist.ftl", import.meta.url), "utf8");
+  const MENU_MESSAGES = [
+    "citegeist-menu-fetch",
+    "citegeist-menu-citing",
+    "citegeist-menu-refs",
+    "citegeist-menu-fetch-collection",
+  ];
+
+  /** The message header line + its indented attribute continuation lines. */
+  function block(id: string): string {
+    const lines = ftl.split("\n");
+    const start = lines.findIndex((l) => l.startsWith(`${id} =`) || l.startsWith(`${id}=`));
+    if (start === -1) return "";
+    let end = start + 1;
+    while (end < lines.length && lines[end].startsWith(" ")) end++;
+    return lines.slice(start, end).join("\n");
+  }
+
+  it("every context-menu message uses .label attribute syntax, never a bare value", () => {
+    for (const id of MENU_MESSAGES) {
+      const b = block(id);
+      expect(b, `${id} must be present in the FTL`).not.toBe("");
+      // A bare value (`id = text`) renders blank on a XUL menuitem because
+      // MenuManager sets dataset.l10nId and the item has no text node.
+      const header = b.split("\n")[0];
+      expect(header.trim(), `${id} header must have no inline value`).toMatch(/=\s*$/);
+      expect(b, `${id} must define a .label attribute`).toMatch(/^\s+\.label\s*=\s*\S/m);
+    }
+  });
+
+  it("fetch actions carry an accesskey; view actions deliberately do not", () => {
+    expect(block("citegeist-menu-fetch")).toMatch(/\.accesskey\s*=\s*G/);
+    expect(block("citegeist-menu-fetch-collection")).toMatch(/\.accesskey\s*=\s*I/);
+    expect(block("citegeist-menu-citing")).not.toMatch(/\.accesskey/);
+    expect(block("citegeist-menu-refs")).not.toMatch(/\.accesskey/);
   });
 });


### PR DESCRIPTION
Fixes #67 — the right-click context menu showing blank entries and then locking up until the plugin is disabled/re-enabled (Zotero 8/9). Ships as an isolated hotfix off `v2.0.4`; the unreleased native-UI work stays separate and will follow as `v2.0.6`.

## Root causes (both verified against Zotero core source, commit `55eceab`)

1. **Blank labels.** `citegeist-menu-*` FTL messages used bare-value syntax. MenuManager sets `dataset.l10nId` on a XUL `<menuitem>`, which Fluent can only fill via the `.label`/`.accesskey` **attributes** — a bare value has no text node to land in, so the item renders empty. Rewritten to `.label` form; accesskeys mirror the DOM fallback path.
2. **Right-click death.** `registerMenus()` treated the `false` from an *already-registered* (process-global) MenuManager as "MenuManager unavailable" and fell back to injecting a **second** DOM menu onto the same popup on any repeat call (File → New Window, hot-reload). A module-level `menuManagerRegistered` guard makes repeat calls a no-op.
3. **Cross-window teardown (found while verifying).** `unregisterMenus(win)` ran on every window close and tore down the *global* MenuManager registration, silently removing the menu from all other open windows. Split into per-window DOM cleanup vs. a new `unregisterGlobalMenus()` that runs once at shutdown.

## Changes
- `addon/locale/en-US/citegeist.ftl` — `.label` / `.accesskey` attribute syntax (U1)
- `src/modules/menu.ts` — idempotency guard + teardown split (U2, U3)
- `src/hooks.ts` — call `unregisterGlobalMenus()` unconditionally at shutdown (U3)
- `test/menu.test.ts` — new coverage; converted to per-test module reload so the new module flag can't leak
- Version bump to `2.0.5` + CHANGELOG + CITATION.cff

## Verification
- `typecheck` · 367 tests · `lint` · `format:check` · `okf:check` · `build` all green locally
- Live multi-window Zotero 9.x QA still to be confirmed by reporters (vitest can't observe real popup/window behavior) — see the plan doc in `docs/plans/` for the manual QA script

Plan: `docs/plans/2026-07-06-001-fix-menu-manager-registration-lifecycle-plan.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)