### PR TITLE
feat: OpenAlex metered-API key handling + author cache foundation (Phase A)

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -159,3 +159,15 @@ The redesigned title-match confirm/discard card (shipped v2.0.1) shows the candi
 
 **Scope:** add `pending_authors TEXT` + a one-shot `ALTER TABLE` migration; thread a formatted author string through `writePendingSuggestion` → `getPendingSuggestion` → `renderSuggestion` (from `match.work.authorships`).
 
+---
+
+## "My Authors" — a deduplicated author index for your library
+
+**Labels:** `enhancement`, `high-impact`, `authors`
+
+v2 follow-up to the author identity layer (see the [author-identity-layer requirements](brainstorms/2026-07-16-author-identity-layer-requirements.md)). Once each library item's authors are resolved to a curated OpenAlex identity, surface a browsable, deduplicated index of every author across the library — each with their Scholar-style profile and a count of how many of your items they wrote. Turns the per-item identity into a first-class way to navigate the library by person.
+
+**Why deferred to v2:** it's a second major surface (its own view plus curation-at-scale) layered on the per-item pane profile and background identity resolution that ship in v1. The identity foundation should prove out before the aggregate view is worth building.
+
+**Depends on:** the `authors` / `item_authors` tables and background identity resolution delivered in v1.
+

--- a/docs/brainstorms/2026-07-16-author-identity-layer-requirements.md
+++ b/docs/brainstorms/2026-07-16-author-identity-layer-requirements.md
@@ -1,0 +1,103 @@
+---
+type: brainstorm
+title: "Author identity layer — requirements"
+description: Requirements brainstorm for resolving, curating, and surfacing OpenAlex author identity in Citegeist, with a Scholar-style author profile in the pane and a synced identity handoff for downstream tools.
+timestamp: 2026-07-16
+tags: [citegeist, brainstorm, authors, openalex, disambiguation, cache, obsidian]
+date: 2026-07-16
+topic: author-identity-layer
+---
+
+# Author Identity Layer
+
+## Summary
+
+Give Citegeist a first-class author layer. It resolves each library item's authors to their OpenAlex identity in the background, lets the user confirm or correct that identity so attribution is trustworthy, and adds a Google-Scholar-style author profile in the item pane — an author's full body of work and metrics, with one-click add-to-library. The curated identity persists in the plugin-owned SQLite store and is exposed as a synced, standards-based assertion that downstream tools (the user's Zotero→Obsidian pipeline) can read.
+
+## Problem Frame
+
+A Zotero creator is a bare name string — `firstName` / `lastName` / `creatorType`, no identifier (`typings/zotero.d.ts:34-39`). Two "J. Wang" entries are indistinguishable, and one person cited as "Baumeister, R." and "Baumeister, R. F." fragments into two apparent authors. OpenAlex already solves this: it disambiguates authorships to stable author IDs (ORCID-anchored where available), and Citegeist already receives that data on every work it fetches for metrics (`src/modules/openalex.ts:47-60`). But the code discards it at display and creator-mapping time (`src/modules/citationNetwork/actions.ts:327-348`).
+
+Two costs follow. First, when the user's notes flow into Obsidian, a claim can't be reliably attributed to a specific person — "who is saying what" rests on name strings that silently collide or split. Second, to see what an author has written the user leaves Zotero for Google Scholar, even though the same publication record sits behind OpenAlex.
+
+## Key Decisions
+
+- **Identity and profile are separate concerns.** *Identity* (which OpenAlex author each creator is) already rides the metrics fetch, so resolving it library-wide costs no extra API calls. *Profile* (h-index, full publication list) needs a new `/authors` + `/works` fetch and happens on demand when an author is viewed. This split maps directly onto the two goals: cheap, always-on attribution vs. rich, occasional browsing.
+
+- **Curation is confirm/override, not merge/split.** OpenAlex proposes the identity; the user can confirm it or override to the correct author when it is wrong or ambiguous, and that curated choice becomes the stored truth that wins over OpenAlex on refresh. This extends the existing confirmed-match pattern (`src/modules/cache/write.ts:206-246`). Rebuilding OpenAlex's clustering (merging two IDs, splitting one) is deliberately out of v1.
+
+- **Source of truth is the plugin-owned SQLite store, not `Extra`.** v1.3.x namespaced data into `Extra`, users objected to the clutter, and v2.0.0 migrated the cache to `citegeist.sqlite` for exactly this reason. Author identity extends that store as normalized `authors` + `item_authors` tables (an item has many authors; an author has many items), never a bolted-on column and never an `Extra` payload.
+
+- **The external handoff is a native Zotero relation, not an `Extra` string.** The curated identity is asserted as a Zotero item relation pointing at the OpenAlex author URI (`https://openalex.org/A…`). Relations are native, Zotero syncs them across devices, they are a semantic-web standard any tool can read, and they keep `Extra` clean. The assertion is item-level ("this paper is by author A…"); exact author position stays in SQLite. Fallback if the relations API proves unworkable: the pipeline reads `citegeist.sqlite` directly.
+
+- **Front-end design is gated.** No visual surface in this feature is implemented without an approved front-end mockup. Any requirement below that renders UI (the pane profile, the curation affordance) must produce a mockup for explicit approval before implementation — the mockup gate blocks the build, not just the review.
+
+## Requirements
+
+**Author identity (foundation)**
+
+- R1. Resolve each library item's authorships to their OpenAlex author identity (`author.id`, `display_name`, `orcid`) from data already fetched during metrics resolution — no additional API call for identity.
+- R2. Persist resolved identity in the plugin-owned SQLite store using normalized `authors` and `item_authors` tables. Do not write identity to `Extra` and do not overload a single `item_cache` column.
+- R3. Resolve identity across the whole library in the background, so attribution is populated for every item, mirroring the coverage model of the citation column rather than resolving only on view.
+- R4. Capture ORCID as the strongest identity anchor whenever OpenAlex supplies it.
+
+**Curation (confirm / override)**
+
+- R5. In the pane, show the OpenAlex-resolved author for each creator and let the user confirm it.
+- R6. Let the user override to the correct OpenAlex author when the resolution is wrong or ambiguous; the curated choice becomes the stored truth and takes precedence over OpenAlex on subsequent refreshes.
+- R7. When OpenAlex offers no author match for a creator, surface that state and allow the creator to remain unresolved without blocking the rest of the item.
+
+**External handoff**
+
+- R8. Assert the curated identity as a native Zotero item relation to the OpenAlex author URI, so a syncing, standards-based, tool-agnostic record of "who wrote this" exists outside the plugin's private store.
+- R9. Keep the handoff passive: Citegeist writes the assertion into Zotero and the user's external pipeline consumes it. Citegeist does not write to Obsidian or own the bridge.
+
+**Author profile (pane, Scholar-style)**
+
+- R10. Opening an author surfaces a profile in the pane: their full body of work plus summary metrics (h-index, i10-index, cited-by count, works count) sourced from the OpenAlex `/authors` and `/works` endpoints.
+- R11. Make the profile actionable — any listed work can be added to the library, reusing the citation-network result rendering and add-to-library path (`src/modules/citationNetwork/results.ts:299-375`, `actions.ts:20-83`).
+- R12. Fetch the profile on demand (only when an author is viewed) and paginate it the way the citation network already does, so a prolific author does not stall the pane.
+- R13. Treat every profile and curation surface as gated by the front-end design decision above: an approved mockup precedes implementation.
+
+## Acceptance Examples
+
+- AE1. **Covers R6.** The user overrides creator "J. Smith" from OpenAlex `A111` to `A222`. On the next metrics refresh, the item still reports `A222`; OpenAlex's `A111` does not overwrite the curated choice.
+- AE2. **Covers R6.** OpenAlex over-splits one real person across `A111` (some papers) and `A333` (others). In v1 the user overrides the `A333` items to `A111` one at a time; the system does not auto-merge the two IDs, and no merge tool is offered.
+- AE3. **Covers R7.** A creator has no OpenAlex author match. The pane shows the creator as unresolved, the rest of the item's authors resolve normally, and the item can be revisited and resolved later.
+
+## Scope Boundaries
+
+**Deferred for later**
+
+- A "My Authors" deduplicated, library-wide author index (browse every author across the library with their profile and item count) — wanted as the explicit v2 follow-up.
+- Full merge/split correction of OpenAlex author clusters.
+- New-work / new-citation author alerts (the "follow this author" side of Google Scholar).
+
+**Outside this feature's identity**
+
+- Citegeist writing into Obsidian directly, or a companion Obsidian plugin — the external pipeline consumes the Zotero-side assertion; Citegeist stays a Zotero plugin.
+- Re-implementing author disambiguation; OpenAlex remains the identity engine, with a curation layer on top.
+
+## Dependencies / Assumptions
+
+- **Zotero relations API is currently unused and untyped in Citegeist** — a grep of `src/` and `typings/` for relation methods returns nothing, and the hand-maintained `typings/zotero.d.ts` declares no relations surface on the item. R8 assumes native Zotero exposes syncing item relations; planning must verify this against the live API and extend the typings. If it does not hold, the documented fallback is direct `citegeist.sqlite` reads by the pipeline.
+- **The OpenAlex `/authors` endpoint is net-new client surface.** The client today only ever calls `/works` (`src/modules/openalex.ts`). R10 adds `/authors/{id}` and `author.id`-filtered `/works` calls, both routed through the existing `rateLimitedFetch`.
+- **New schema.** The `authors` / `item_authors` tables are additive to `citegeist.sqlite` (`src/modules/cache/db.ts:28-58`) and must honor the compile-time column-exhaustiveness gate in `src/modules/cache/types.ts:191-193`.
+- **Identity resolution depends on `authorships` staying in the fetch selection** (`src/modules/openalex.ts:255`, `:262`) and in `normalizeWork` (`:464-468`); losing that field silently disables R1.
+
+## Outstanding Questions
+
+**Deferred to planning**
+
+- Exact column shape of the `authors` / `item_authors` tables.
+- The relation predicate to assert (e.g. `owl:sameAs` vs. a `dc:creator`-style term) and whether to also assert affiliation.
+- How the confirm/override affordance attaches within the pane (subject to the mockup gate).
+- Whether background resolution backfills already-cached items or only populates on the next per-item refresh.
+
+## Sources / Research
+
+- Authorships (with `author.id` / `orcid`) parsed and retained: `src/modules/openalex.ts:47-60`, `:464-468`; discarded downstream at `src/modules/citationNetwork/actions.ts:327-348` and `formatAuthors` (`src/modules/openalex.ts:610`).
+- Curated-truth pattern to extend: `src/modules/cache/write.ts:206-246` (SQLite write) and `:292-333` (the `Extra` mirror it deliberately keeps minimal); recovery at `src/modules/cache/migration.ts:237-262`.
+- Cache schema + exhaustiveness gate: `src/modules/cache/db.ts:28-58`, `src/modules/cache/types.ts:158-193`.
+- Relations unused; creator carries no identifier: grep of `src/` + `typings/` (zero matches), `typings/zotero.d.ts:34-39`.
+- Reusable surfaces: pane section `src/modules/citationPane.ts:200`, tree column `src/modules/citationColumn.ts:216`, menus `src/modules/menu.ts:75`; works-list render + add-to-library `src/modules/citationNetwork/results.ts:299-375`, `actions.ts:20-83`.

--- a/docs/plans/2026-07-16-001-feat-author-identity-layer-plan.md
+++ b/docs/plans/2026-07-16-001-feat-author-identity-layer-plan.md
@@ -1,0 +1,337 @@
+---
+type: plan
+title: "feat: Author identity layer"
+description: Implementation plan for resolving, curating, and surfacing OpenAlex author identity in Citegeist — background identity resolution, a Scholar-style author profile pane, a synced Zotero-relation handoff, and July-2026 metered-API / API-key handling.
+timestamp: 2026-07-16
+tags: [citegeist, plan, authors, openalex, disambiguation, cache, api-key, obsidian]
+date: 2026-07-16
+origin: docs/brainstorms/2026-07-16-author-identity-layer-requirements.md
+---
+
+# feat: Author Identity Layer
+
+> Requirement IDs (R1–R13) and Acceptance Examples (AE1–AE3) are defined in the origin doc: `docs/brainstorms/2026-07-16-author-identity-layer-requirements.md`. This plan references them; it does not redefine them.
+
+## Summary
+
+Give Citegeist a first-class author layer. Resolve each library item's authors to their OpenAlex identity as items are fetched, let the user confirm or correct that identity so attribution is trustworthy, and add a Google-Scholar-style author profile in the item pane — an author's works and derived metrics, with one-click add-to-library. Curated identity persists in new normalized SQLite tables and is asserted as a synced, standards-based Zotero relation the user's Obsidian pipeline can read. Because OpenAlex moved to a metered/paid model (July 2026), the plan's foundation is correct API-key handling; identity resolution adds no *new* per-item call but is not retroactively free for an already-cached library (see KTD8).
+
+## Problem Frame
+
+A Zotero creator is a bare name string — no identifier (`typings/zotero.d.ts:34-39`). Two "J. Wang" entries are indistinguishable; one person split across "Baumeister, R." and "Baumeister, R. F." fragments into two apparent authors. OpenAlex already disambiguates authorships to stable author IDs (ORCID-anchored where available), and that data arrives on every work Citegeist fetches for metrics (`src/modules/openalex.ts:47-60`) — but the code discards it at display and creator-mapping time (`src/modules/citationNetwork/actions.ts:327-348`). The result: notes flowing into Obsidian can't reliably attribute a claim to a person, and to see an author's body of work the user must leave Zotero for Google Scholar.
+
+Two constraints discovered during research reshape the build (see origin, and Sources below):
+- **OpenAlex is now metered/paid** and has dropped the `mailto` polite pool. Singleton author lookups are free; works-list calls are metered against a daily budget. Citegeist's fetch layer is built on the obsolete `mailto` mechanism and affects *every* current call (citation counts, rankings), not just the author feature — so fixing it is both foundational and urgent (see Delivery & Sequencing).
+- **The OpenAlex Authors entity is returning zeroed aggregates** in production while the Works index is healthy — so author metrics are derived from works, with a fallback to the (free, exact) author aggregates when they return non-zero (KTD2).
+
+---
+
+## Key Technical Decisions
+
+- **KTD1 — Metered-API + API-key handling is the foundation (July-2026 best practice).** OpenAlex meters requests ($0.10/day anonymous, $1/day with a free key; singleton lookups free, list+filter ~$0.0001/call). Add an **optional** API key — opt-in, no default baked in (mirrors the no-default-`mailto` stance, `feedback_no_default_openalex_mailto` memory). Store it in a Zotero pref rendered as a password field. Security controls (all in U1):
+  - **Redaction is centralized, not per-callsite.** Sanitize the key out of any URL/message **inside `normalizeError`/the throw path**, so no route to `Zotero.debug` can leak it — `openalex.ts` already logs caught errors via direct `Zotero.debug(normalizeError(e))` in its retry paths that bypass `logError`. Redaction scoped only to `logError` is insufficient.
+  - **Prefer header auth**; fall back to the `api_key` query param only if OpenAlex has no header form (an Open Question), and rely on centralized redaction when the key rides the URL.
+  - **Distinguish three error states, not two:** `OpenAlexBudgetError` (budget exhausted — prompts for a key), `OpenAlexNetworkError` (unreachable), and an invalid/revoked-key state (`401/403` — prompts re-entry). A `429` maps to `OpenAlexBudgetError` **only on a positive discriminator** (e.g. `X-RateLimit-Remaining: 0` or a budget error body code); otherwise it retains the existing transient-`429` retry path (`openalex.ts:149-157`).
+  - The key is kept in a plain pref; note the at-rest trade-off (see Risks). Remove the now-dead `mailto` send. This supersedes the brainstorm's "carve `mailto` out" call — per the user's steer (captured this session), correct key handling is in-scope and sequenced first.
+
+- **KTD2 — Author metrics: prefer the free author aggregates, derive from works only when they're zero.** OpenAlex `/authors/{id}` aggregates (`works_count`, `cited_by_count`, `summary_stats`) are currently returning zero while the Works index is healthy. Use the author-object aggregates when present and non-zero (free, exact); **derive from the works list only when they're zero/absent** (`works_count` = `meta.count`, h-index computed from works). This hybrid is robust to both the current degradation and its recovery, and avoids permanently paying metered list+filter budget for a less-precise `≥` metric once the aggregates heal. Use `/authors/{id}` for identity (canonical id, `display_name`, `orcid`) regardless.
+
+- **KTD3 — Persist the canonical author id and reconcile 301 merges.** OpenAlex churns author IDs; a stored `A…` can `301` to a survivor. Persist the `id` returned in the response body, not the id requested. When a profile fetch observes `body.id ≠ requested id`, reconcile: rewrite matching `item_authors` rows to the survivor, GC the orphaned `authors` row, and re-assert the relation URI. (Background piggyback stores the embedded authorship id as-is; reconciliation happens at the next profile/singleton fetch.)
+
+- **KTD4 — Normalized tables, additive-only.** New `authors` and `item_authors` tables via `CREATE TABLE IF NOT EXISTS` in `db.ts` init — idempotent, no schema-version gate, no `ALTER TABLE`. This sidesteps the missing column-add path that deferred `pending_authors` (`docs/BACKLOG.md`); do **not** add an `item_cache` column instead. Composite keys reflect the v3 cache lesson (item keys unique only within a library): `item_authors` keyed `(library_id, item_key, author_id)`, `authors` keyed on the globally-unique `author_id`. The compile-time exhaustiveness and bind-shape gates (`src/modules/cache/types.ts:189-193`, `:238-242`) are hardcoded to `ItemCacheRow` and must be **replicated per new row type**. Validate `author.id` at the write boundary with a length-bounded `/^A\d{1,20}$/`.
+
+- **KTD5 — No second in-memory mirror in v1.** The `item_cache` mirror exists only because the column `dataProvider` is synchronous. v1 surfaces authors solely in the pane (async `onAsyncRender`), so author reads query SQLite asynchronously — no second sync mirror. Because there is no mirror, the curated-row preservation in KTD7 is an async read-modify-write that **must run inside the author sub-module's own per-key lock** (see KTD7).
+
+- **KTD6 — Relations handoff is item-level, with a validated spike first.** Assert a custom `openalex:author` predicate (letters-colon-letters, which Zotero's `setRelations` validation requires) pointing at the author URI, at confirm time, only when `item.library.editable`. Relations are item-level; per-creator/position identity lives in `item_authors`. An **override removes the superseded relation value before asserting the corrected one** (`removeRelation`/`setRelations`, mirroring the replace discipline of `item_authors`). Extend `typings/zotero.d.ts` with the six relation methods **and** a `library` accessor (the gate `item.library.editable` needs it; the hand-rolled `Item` exposes only `libraryID`). The custom-predicate **sync server round-trip is unverified** and load-bearing — validate it in a pre-U5 spike (below) before U6–U8 build on it, and keep the direct-`citegeist.sqlite`-read fallback in scope (Scope Boundaries).
+
+- **KTD7 — Curated identity wins over OpenAlex, enforced under lock.** A confirmed/overridden author id is stored as truth and not overwritten by a later refresh (origin AE1). The private `withKeyLock`/`mutateRow` in `db.ts` are table-specific to `item_cache`; the author sub-module **replicates its own per-`(library_id, item_key)` lock**, and `cacheItemAuthors` performs the `is_curated` preservation as a SELECT-then-UPSERT **inside that lock** so a background resolve (U3) interleaving with a user override (U8) cannot clobber the curated row.
+
+- **KTD8 — Rollout coverage is not free; lazy backfill is a metered re-fetch.** Forward fetches resolve identity with no *new* call (KTD9). But existing users have a cache-fresh `item_cache` (7-day lifetime), so `fetchAndCacheItem` short-circuits at the freshness check (`citationService.ts:205/:233`) **before** the resolution callsite — piggyback does not run for them, and `item_cache` never stored `authorships`. Meaningful day-one coverage therefore requires the metered "resolve all authors" pass (U4), which re-fetches works. Default is lazy (as items naturally refresh) plus that explicit opt-in pass; no eager sweep on upgrade.
+
+- **KTD9 — Identity resolution piggybacks the metrics fetch (three callsites).** The `work` object already carries `authorships` at all three `cacheWorkData` callsites — `src/modules/citationService.ts:212, :255` and `src/modules/citationNetwork/actions.ts:62` (add-from-network). Persist author identity at all three for no new API call on forward items. Repaint via per-item `invalidateColumnCache(item.id)` + the 150 ms debounce (`project_column_repaint` memory). Apply the trashed-item guard.
+
+---
+
+## High-Level Technical Design
+
+Source-of-truth fan-out: OpenAlex work data feeds the SQLite author tables (the authority), which fan out to the pane profile and the Zotero relation; the relation is what the external Obsidian pipeline consumes. The API key governs every metered path.
+
+```mermaid
+flowchart TB
+  OA["OpenAlex /works (metrics fetch)\nauthorships[].author.{id,orcid}"] -->|piggyback, no new call| RES[cacheItemAuthors]
+  RES --> DB[("SQLite: authors + item_authors\n(source of truth)")]
+  CONF["User confirm / override (pane)"] -->|curated truth, under lock| DB
+  DB --> PANE["Pane: resolved authors + curation"]
+  DB -->|on confirm, if library editable| REL["Zotero item relation\nopenalex:author -> author URI"]
+  REL -->|syncs via Zotero| PIPE["External MCP pipeline -> Obsidian"]
+  DB -.fallback: direct read.-> PIPE
+  PROF["Author profile view (pane)"] -->|on demand| AUTHORS["/authors/{id} (free identity + aggregates)\n+ /works?filter=authorships.author.id (metered, when aggregates zero)"]
+  AUTHORS -->|301 reconcile| DB
+  KEY["API key (opt-in pref) + budget-aware fetch"] -.governs.-> AUTHORS
+  KEY -.governs.-> OA
+```
+
+Diagram is directional; the IDed prose below is authoritative.
+
+---
+
+## Delivery & Sequencing
+
+Ship **one PR per phase**, in order. Phase A is a self-contained, independently valuable release and should ship **first, as its own version, ahead of the author feature** — it rewrites the shared `rateLimitedFetch`/`fetchJson` choke point that every current OpenAlex call already depends on, so the metered-API correctness + key handling benefits (and de-risks) all existing functionality immediately, and isolates that blast radius from the author units (aligns with `project_release_flow`: ship a live-degradation fix isolated). Phase B builds identity + handoff on the schema. Phase C's three units are each independently mockup-gated and land as separate reviewable changes once their mockups clear. Phase D (docs) trails.
+
+- **Phase A (own release):** U1 (metered fetch + key handling), U2 (author schema).
+- **Phase B:** U3, U4, U5 (+ the pre-U5 relation-sync spike).
+- **Phase C (each mockup-gated):** U6, U7, U8, U9.
+- **Phase D:** U10.
+
+---
+
+## Output Structure
+
+```text
+src/modules/cache/authors/
+  types.ts        # AuthorRow, ItemAuthorRow, per-table COLUMNS + replicated compile-time gates
+  db.ts           # CREATE TABLE IF NOT EXISTS authors / item_authors; per-key lock; two-level orphan GC
+  read.ts         # async SQLite reads (no sync mirror in v1)
+  write.ts        # upsertAuthor (metric-preserving), cacheItemAuthors (curated-preserving, under lock)
+  relations.ts    # openalex:author assert/retract/read; editability gate
+  index.ts        # public surface
+src/modules/openalexAuthors.ts   # /authors singleton (+aggregates) + author-filtered /works + derived metrics + 301 reconcile
+test/authorCache.test.ts
+test/authorRelations.test.ts
+test/openalexAuthors.test.ts
+```
+
+Per-unit `**Files:**` remain authoritative; the tree is the expected shape, not a constraint.
+
+---
+
+## Implementation Units
+
+### Phase A — Foundation (ship first, own release)
+
+### U1. Metered-OpenAlex fetch layer + API-key handling
+
+- **Goal:** Make the fetch layer correct for July-2026 OpenAlex: optional API key, centralized redaction, three-way error discrimination, dead-`mailto` removal.
+- **Requirements:** Enables R1/R10/R3 under a metered API; realizes KTD1, KTD3.
+- **Dependencies:** none (sequenced first).
+- **Files:** `src/modules/openalex.ts`, `src/modules/utils.ts` (centralized redaction in `normalizeError`), `src/constants.ts`, `addon/` prefs plumbing (pref key only; the visual field is U9), `test/openalex.test.ts`.
+- **Approach:** Add `PREF_OPENALEX_API_KEY` (local pref, no default). Attach the key via request header if OpenAlex accepts it, else `api_key` query param. **Redact the key inside `normalizeError`/the throw path** so every route to `Zotero.debug` is covered, not just `logError`. Widen `fetchJson`'s response destructure to keep `getResponseHeader` (`openalex.ts:125` currently drops it) and parse `X-RateLimit-*` into a budget snapshot. Introduce `OpenAlexBudgetError` (mapped from `429` only on a positive budget discriminator; transient `429` keeps retrying) and an invalid-key state (`401/403`). Add `resolveCanonicalId(response)` reading `body.id`. Stop sending `params.mailto` and the `no-mailto` User-Agent; retire `PREF_MAILTO`.
+- **Patterns to follow:** `rateLimitedFetch`/`fetchJson` (`src/modules/openalex.ts:114-173`), three-way outcome discipline (`docs/DESIGN.md`), constants block (`src/constants.ts:1-14`).
+- **Test scenarios:**
+  - Key present → sent via the chosen mechanism; absent → anonymous request still issued and succeeds.
+  - Key never reaches `Zotero.debug` **via any path** — assert on a forced error in the `fetchJson` retry branch (not only a `logError` call).
+  - Budget-`429` (positive discriminator) → `OpenAlexBudgetError`, no retry; transient `429` (no discriminator) → retried then `OpenAlexNetworkError`; `401/403` → invalid-key state.
+  - `resolveCanonicalId` returns the body id when it differs (301).
+  - `mailto` absent from every outgoing request.
+- **Verification:** anonymous and keyed fetches succeed; no key in logs on any path; budget/network/invalid-key are distinguishable by callers.
+
+### U2. Author cache sub-module (schema + read/write + lock + test harness)
+
+- **Goal:** Persist author identity in normalized, additive SQLite tables with the same safety guarantees as `item_cache`, under a replicated per-key lock.
+- **Requirements:** R2; realizes KTD4, KTD5, KTD7.
+- **Dependencies:** none (parallel to U1).
+- **Files:** `src/modules/cache/authors/{types,db,read,write,index}.ts`, `src/modules/cache/db.ts` (invoke new `CREATE TABLE`s in `doInit`), `test/_helpers/fakeDb.ts` (teach it the new SQL), `test/authorCache.test.ts`.
+- **Approach:** `authors(author_id PK, display_name, orcid, works_count, cited_by_count, h_index, i10_index, last_fetched)`; `item_authors(library_id, item_key, author_id, author_position, is_curated, PRIMARY KEY(library_id,item_key,author_id))`. Define `AuthorRow`/`ItemAuthorRow` with their own `COLUMNS` tuples and **replicated** `_AllColumnsCovered` + `_RowFieldsAreBindShape` gates (template `src/modules/cache/types.ts:158-193`). Replicate a per-`(library_id,item_key)` lock (the `item_cache` one is private). `cacheItemAuthors(item, authorships)` validates each `author.id` (`/^A\d{1,20}$/`), then **inside the lock** SELECTs existing rows, preserves any `is_curated=1` row, and UPSERTs identity fields only. `upsertAuthor` is metric-preserving: it sets `display_name`/`orcid` on the piggyback path and **preserves existing metric columns** (mirror `cacheWorkData`'s `sourceStats ? … : base.X` idiom, `write.ts:112`) — metric columns are written only by the profile fetch (U6). Extend orphan GC with two sweeps: `item_authors` for deleted items, `authors` orphaned of all `item_authors`. No in-memory mirror.
+- **Patterns to follow:** `src/modules/cache/{types,db,write}.ts`, v3 amendments in `docs/plans/2026-05-27-001-feat-sqlite-cache-migration-plan.md`, `test/_helpers/fakeDb.ts` (throws on unknown SQL — new statement shapes must be taught in this unit).
+- **Test scenarios:**
+  - Both tables created; re-init on an existing DB is a no-op.
+  - Same item key in two libraries stores distinct `item_authors` rows.
+  - Invalid author id (`W123`, empty, over-length) rejected at the boundary.
+  - Delete GCs `item_authors`; an author with no remaining refs is GC'd; a still-referenced author is retained.
+  - **Concurrent** override + background `cacheItemAuthors` on the same item: the curated row survives (lock holds — not merely a sequential test).
+  - `upsertAuthor` on the piggyback path does not null existing metric columns.
+  - Compile-time: dropping a `COLUMNS` field fails typecheck.
+- **Verification:** author tables populate via the fake harness; typecheck enforces coverage; curated rows and metrics survive concurrent writes.
+
+### Phase B — Identity resolution & handoff
+
+### U3. Background identity resolution (piggyback, three callsites)
+
+- **Goal:** Resolve author identity for every forward-fetched item with no new API call.
+- **Requirements:** R1, R3 (forward coverage); realizes KTD9.
+- **Dependencies:** U2.
+- **Files:** `src/modules/citationService.ts`, `src/modules/citationNetwork/actions.ts`, `test/citationService.test.ts`.
+- **Approach:** Call `cacheItemAuthors(item, work.authorships)` after all three `cacheWorkData` callsites (`citationService.ts:212, :255`; `citationNetwork/actions.ts:62`), where `work` is in scope. Guard on `!item.deleted && item.isRegularItem()`. Wrap the identity write so its failure cannot corrupt the already-persisted metrics result (log and continue). Trigger `invalidateColumnCache(item.id)` per item. Note in-code that at rollout this only covers items that (re)fetch — cache-fresh items wait for U4 or natural staleness (KTD8).
+- **Patterns to follow:** `cacheWorkData` trust boundary (`write.ts:74-121`), per-item invalidation (`citationColumn.ts:451-491`).
+- **Test scenarios:**
+  - Each of the three callsites persists one `item_authors` row per authorship with correct positions.
+  - A trashed item is skipped.
+  - Empty `authorships` writes nothing and does not throw.
+  - A thrown identity write does not fail the metrics result.
+- **Verification:** after a fetch from any of the three paths, resolved authors are readable; failures isolate from metrics.
+
+### U4. Lazy + opt-in "resolve all authors" backfill
+
+- **Goal:** Cover the existing library without an eager, metered sweep, with honest progress reporting.
+- **Requirements:** R3 (existing-library coverage); realizes KTD8.
+- **Dependencies:** U1, U2, U3.
+- **Files:** `src/modules/citationService.ts`, `src/modules/menu.ts`, `src/constants.ts`, `test/citationService.test.ts`, `test/menu.test.ts`.
+- **Approach:** Explicit user-triggered "Resolve authors for selected / library" pass that re-fetches works for items lacking `item_authors`, rate-limited via `rateLimitedFetch`. Add a distinct **"not attempted (budget)"** outcome to the batch result summary (separate from errors — the same miscounting class `summarizeBatch` already had to patch), surfaced in the progress-window final message. On `OpenAlexBudgetError`, stop further calls, report partial progress + the budget prompt (U9), and do not cache "no author". Menu entry behind the process-global registration guard; split per-window vs global teardown (`reference_zotero_menumanager` memory). Provide a cancellation affordance (the pass now spends metered budget).
+- **Patterns to follow:** `fetchAndCacheItems` + `onItemDone` (`citationService.ts:324-362`), `summarizeBatch` outcome vocabulary, #67 menu guards.
+- **Test scenarios:**
+  - Resolves only items missing `item_authors`; resolved items skipped.
+  - Budget error mid-pass halts calls; summary distinguishes budget-stopped items from genuine no-match errors.
+  - Menu entry registers once across repeat `registerMenus`.
+  - Cancellation stops the pass and reports partial progress.
+  - `Covers AE3.` No-match items are left unresolved and re-attemptable.
+- **Verification:** a mixed library backfills only gaps, respects budget, and reports budget-stops distinctly.
+
+### U5. Zotero relations handoff (+ pre-U5 sync spike)
+
+- **Goal:** Expose curated identity as a native, synced Zotero relation the external pipeline can read — after verifying the round-trip.
+- **Requirements:** R8, R9; realizes KTD6.
+- **Dependencies:** U2. **Pre-U5 spike (blocks U5):** on two synced devices, write an `openalex:author` relation, sync, and confirm the custom predicate survives the server round-trip and is readable. If it does not survive, fall back to the direct-`citegeist.sqlite` read for the pipeline (Scope Boundaries) and record it before building U6–U8 on the relation.
+- **Files:** `typings/zotero.d.ts` (six relation methods + `library` accessor on `interface Item`), `src/modules/cache/authors/relations.ts`, `test/authorRelations.test.ts`.
+- **Approach:** On confirm/override, and only when `item.library.editable`, assert `addRelation("openalex:author", "https://openalex.org/" + authorId)` and `saveTx()`. On override, `removeRelation` the superseded value (or `setRelations` the reconciled set) before asserting the new one. Provide `getRelationsByPredicate("openalex:author")` for the pipeline/parity.
+- **Patterns to follow:** "offer to add DOI on confirm" (`docs/DESIGN.md`), the Extra-mirror-on-confirm shape (`write.ts:292-333`) as analogue.
+- **Test scenarios:**
+  - Confirm writes the relation with the correct URI; a non-editable library is skipped.
+  - Override removes the superseded relation and asserts the new one (no stale/duplicate URI left).
+  - Re-confirming the same author does not duplicate.
+  - Predicate is letters-colon-letters.
+- **Verification:** spike confirms round-trip; confirmed items expose the relation; read-only libraries untouched.
+
+### Phase C — Profile & curation (front-end gated)
+
+> **Front-end design gate (origin R13):** U7, U8, U9 render new visual surfaces. Each requires an approved static mockup and explicit front-end sign-off **before** implementation (the project-local PreToolUse hook enforces this on `ui/*.ts`, `citationPane.ts`, `citationNetwork/styles.ts`/`results.ts`, `*.xhtml`, `*.css`). Build from `cgComponents` primitives; add new colour as `--cg-*` tokens; keep gallery parity (`test/ui-primitives.test.ts`). The interaction/state decisions specified per unit are settled here regardless of layout.
+
+### U6. OpenAlex authors client
+
+- **Goal:** Fetch author identity + works, derive/choose metrics, reconcile 301 merges.
+- **Requirements:** R10, R12; realizes KTD2, KTD3.
+- **Dependencies:** U1, U2.
+- **Files:** `src/modules/openalexAuthors.ts`, `src/constants.ts` (page size + h-index page cap), `test/openalexAuthors.test.ts`.
+- **Approach:** `getAuthor(id)` → `/authors/{id}` singleton (free) for identity + canonical id + aggregates, with a session `authorStatsCache` (template `getSourceStats`, `openalex.ts:516-561`). **Metrics per KTD2:** use author-object aggregates when non-zero; else derive from works. `getAuthorWorks(id, cursor)` → `/works?filter=authorships.author.id:{id}`, `LIST_SELECT`, `sort=cited_by_count:desc`, `per_page=100`, cursor paging (template `getCitingWorks`, `:377-392`). When deriving h-index, cap at `AUTHOR_HINDEX_PAGE_CAP` pages and label the value `≥` when the cap is hit. On `body.id ≠ requested id`, run the KTD3 reconciliation (rewrite `item_authors`, GC orphan `authors`, re-assert relation). All calls through `rateLimitedFetch`.
+- **Patterns to follow:** `getCitingWorks` cursor paging, `getSourceStats` singleton + session cache, three-way error handling.
+- **Test scenarios:**
+  - `getAuthor` returns identity + canonical id when the response id differs (301) and triggers reconciliation.
+  - Aggregates non-zero → used directly; aggregates zero → derived from works.
+  - Derived h-index matches a fixture; cap hit → value labeled `≥`.
+  - `getAuthorWorks` pages via cursor to `next_cursor: null`.
+  - Budget error propagates as `OpenAlexBudgetError`.
+- **Verification:** identity + metrics correct under both aggregate states; 301 reconciles; cost bounded.
+
+### U7. Scholar-style author profile in the pane  *(front-end gated)*
+
+- **Goal:** Show an author's works + metrics with add-to-library and complete interaction states.
+- **Requirements:** R10, R11, R12, R13.
+- **Dependencies:** U6; reuses U2 reads to enumerate an item's resolved authors.
+- **Files:** `src/modules/citationPane.ts`, `src/modules/ui/components.ts` (only if a new primitive is needed), `docs/design-system/citegeist-primitives.html` (gallery parity if so), `test/citationPane.test.ts`.
+- **Approach:** Profile render mode: metrics header + paginated works list, reusing citation-network rows + `addItemToLibrary` (`results.ts:299-375`, `actions.ts:20-83`). Fetch on demand in `onAsyncRender` under the `paneGeneration` stale-render guard (body is reused). **Explicit states:** in-progress (reuse network loading), `OpenAlexBudgetError` (point at the U9 key banner), `OpenAlexNetworkError` (retry affordance), zero-works author (distinct from error). Guard against `onAsyncRender` running before `initCache()` (cache-not-ready → graceful empty). A resolved author name in U8 opens this profile; a back affordance returns to the curation list. CDATA-wrap `<style>`; buttons via `createElement`+`addEventListener`; `escapeHTML` values; `applyHostScheme` if portaled to `doc.body`.
+- **Patterns to follow:** `renderPane`/`renderSuggestion` (`citationPane.ts:651-1015`), network results, `project_pane_bodyxhtml_xml_safety` memory.
+- **Test scenarios:**
+  - Profile renders metrics + first works page from a fixture author.
+  - Each state renders: loading, budget-exhausted, network-error, zero-works.
+  - Add-to-library adds a listed work via the reused path.
+  - Pagination loads the next page; a stale render (item switched mid-fetch) is discarded.
+  - Emitted pane XHTML is XML-safe.
+- **Verification:** a correct, paginated, actionable profile with all states — verified in Zotero 9 dark after mockup approval.
+
+### U8. Confirm / override curation UI in the pane  *(front-end gated)*
+
+- **Goal:** Confirm or correct an item's resolved authors; persist as truth; drive the relation; communicate state honestly.
+- **Requirements:** R5, R6, R7, R13; realizes KTD7.
+- **Dependencies:** U2, U5, U6.
+- **Files:** `src/modules/citationPane.ts`, `test/citationPane.test.ts`.
+- **Approach:** Per-creator display with confirm/override affordances (model `renderSuggestion`/`makeGuardedButton`). Confirm/override writes the curated `item_authors` row (under lock, U2) and drives the relation (U5). **Override input** accepts pasting any OpenAlex author URL/ID or an ORCID (singleton lookup) — not author name-search (degraded) — so AE2's "correct author isn't a co-author" case is satisfiable. **State copy** distinguishes "not linked yet" (never attempted / in-flight) from "no OpenAlex match" (R7); the open pane re-renders when a background resolution completes for the selected item. **Read-only library:** confirm/override still saves locally but shows a visible "Saved locally — not synced (read-only library)" note, since the relation write is skipped.
+- **Patterns to follow:** `renderSuggestion` confirm/dismiss + guarded buttons (`citationPane.ts:651-853`), curated-wins contract (KTD7 / AE1).
+- **Test scenarios:**
+  - `Covers AE1.` Override persists; a later refresh does not overwrite it.
+  - `Covers AE2.` Over-split corrected via pasted author id; no auto-merge offered.
+  - `Covers AE3.` No-match creator shows the "no match" state; never-attempted shows "not linked yet".
+  - Confirm in an editable library triggers exactly one relation write; a read-only library writes none and shows the local-only note.
+  - Guarded confirm acts once on double-click.
+- **Verification:** curation persists, wins over refresh, drives the relation, and communicates read-only + pending honestly — verified after mockup approval.
+
+### U9. API-key entry UX — pref field + right-time prompt  *(front-end gated)*
+
+- **Goal:** Get the user's optional key entered at the right moment, the best-practice way, with correct copy for every state.
+- **Requirements:** Supports KTD1.
+- **Dependencies:** U1.
+- **Files:** `addon/` preferences XHTML, `src/modules/citationPane.ts` (inline prompt), `src/modules/ui/components.ts` (reuse `.cg-banner`), `test/citationPane.test.ts`.
+- **Approach:** A password-type key field in preferences with a one-line rationale + link to the free key page. Plus an **inline, dismissible** `.cg-banner` surfaced only when a budget-limited action is blocked or `OpenAlexBudgetError` occurs — never on startup. **Dismissal persists until the next budget reset** (a `dismissed-until` pref), not permanently and not per-render. **Copy branches on key presence:** no key → "add a free API key to raise your daily budget"; keyed-and-exhausted → "today's OpenAlex budget is used up — resets tomorrow" + remaining-budget from the `X-RateLimit-*` snapshot. The field writes the U1 pref; the key is never rendered back in full or logged.
+- **Patterns to follow:** existing preferences pane, `.cg-banner`, `feedback_no_default_openalex_mailto` (opt-in; anonymous still works).
+- **Test scenarios:**
+  - Entering a key persists it; clearing reverts to anonymous.
+  - The prompt appears only after a budget-limited action / budget error; dismissal persists until the next reset window, then re-prompts.
+  - Copy differs for no-key vs keyed-and-exhausted.
+  - The key is not echoed in full in the DOM nor logged.
+  - With no key, all flows work at the anonymous budget.
+- **Verification:** key entry works from pref and inline prompt; copy is correct per state; anonymous unaffected — verified after mockup approval.
+
+### Phase D — Durability
+
+### U10. Promote hard-won patterns to `docs/solutions/`
+
+- **Goal:** Close the documentation gap on patterns this feature relies on and re-touches (surfaced in research; approved in scope synthesis). Ships as a trailing docs-only change.
+- **Requirements:** Long-term-health follow-through (not an origin R — a plan-local durability unit).
+- **Dependencies:** none.
+- **Files:** `docs/solutions/ui-bugs/` (pane `bodyXHTML` XML/CDATA safety), `docs/solutions/` (Zotero 8/9 column repaint via `refreshAndMaintainSelection`).
+- **Approach:** Write two short OKF solution docs from the existing project-memory notes (`project_pane_bodyxhtml_xml_safety`, `project_column_repaint`), matching existing `docs/solutions/` frontmatter.
+- **Test scenarios:** Test expectation: none — documentation only; `npm run okf:check` must pass.
+- **Verification:** both docs conform to OKF and pass `okf:check`.
+
+---
+
+## Scope Boundaries
+
+**Deferred for later (v2+, per origin):**
+- A browsable, deduplicated "My Authors" library-wide index (logged in `docs/BACKLOG.md`).
+- Full merge/split correction of OpenAlex author clusters.
+- New-work / new-citation author alerts.
+- An author column in the item tree (would require the second sync mirror, KTD5).
+
+**Outside this feature's identity (per origin):**
+- Citegeist writing into Obsidian directly, or a companion Obsidian plugin — the external pipeline consumes the Zotero relation (or, if the sync spike fails, reads `citegeist.sqlite` directly — the retained fallback).
+- Re-implementing author disambiguation; OpenAlex remains the identity engine.
+
+**Deferred to follow-up work:**
+- None. The `mailto → api_key` migration is folded into U1 per the user's steer (metered-API handling is foundational). U10 (docs) is in-scope as a trailing durability unit, not a separate PR.
+
+---
+
+## Provider Resilience (posture, not v1 code)
+
+Author *identity* is provider-specific — an OpenAlex `A…` id is a different namespace from a Semantic Scholar `authorId`, built by a different model; the only cross-provider anchor is **ORCID**. This shapes how v1 stays swap-friendly *without* building a second provider (a provider abstraction is explicitly out of scope):
+
+- **ORCID is the durable identity spine.** Where an author has an ORCID, treat it as the authoritative "who," with the OpenAlex `A…` id as the fetch handle — a stable ORCID-anchored identity survives a future provider swap because it is not vendor-specific. v1 already captures ORCID in the `authors` table (KTD4); prefer it as the reconciliation key wherever present.
+- **Keep the seam, not the wall.** The isolated fetch layer (U1) and normalized `authors` / `item_authors` tables (U2) make a future `source` column (`openalex` / `semanticscholar`) a small, non-foreclosing addition. Do not build the abstraction in v1.
+- **Named fallbacks if OpenAlex becomes untenable:** **Semantic Scholar** is the designated identity + metrics fallback (the only other free source with real author entities and h-index); **Crossref** is the works / DOI / reference backup (no author disambiguation). Verify Semantic Scholar's live API status and limits before betting on it.
+- The plan already hedges the *observed* OpenAlex Authors-aggregate degradation via works-derived metrics (KTD2) — no second provider is needed for that failure mode.
+
+---
+
+## Risks & Mitigations
+
+- **Rollout coverage is not free (KTD8).** Cache-fresh libraries get near-empty forward coverage until items refresh; day-one coverage needs the metered U4 pass. The Summary and KTD8 state this honestly so the "free" framing doesn't mislead.
+- **Custom-predicate sync round-trip (R8/R9) is unverified and load-bearing.** Mitigated by the pre-U5 spike on two synced devices before U6–U8 build on the relation, and the retained direct-`citegeist.sqlite` fallback.
+- **Curated-wins write race.** The `is_curated` preservation runs as an async read-modify-write **inside the replicated per-key lock** (KTD7); a concurrent (not just sequential) test asserts it.
+- **301 author merges of already-persisted ids.** KTD3 reconciles at the next profile/singleton fetch (rewrite `item_authors`, GC orphan, re-assert relation); background piggyback stores the embedded id until then. (Not a live server-merge watcher — reconciliation is fetch-triggered, stated as such.)
+- **OpenAlex Authors degradation.** KTD2's hybrid uses free exact aggregates when non-zero and derives from works only when zeroed — robust and cost-minimal in both states.
+- **Budget vs transient `429`.** U1 maps to `OpenAlexBudgetError` only on a positive discriminator; the actual signal is an Open Question to confirm live.
+- **Key leakage.** Redaction is centralized in `normalizeError`/the throw path (KTD1), covering the direct-`Zotero.debug` retry calls that bypass `logError`; a U1 test forces an error in that path.
+- **Key at rest.** The key lives in a plaintext pref; a user syncing their whole Zotero profile directory via a cloud folder would carry it across devices. Documented trade-off; if unacceptable, evaluate Zotero's Login Manager (`Services.logins`) — noted, not adopted in v1.
+- **Reused pane `body`.** The `paneGeneration` guard wraps every await in U7/U8.
+- **Fake-DB coupling.** `test/_helpers/fakeDb.ts` throws on unknown SQL — each new statement shape is taught in U2.
+
+## Dependencies / Assumptions
+
+- **Zotero relations API** lives on `Zotero.DataObject` (inherited by `Item`), stable across Zotero 7/8/9; `typings/zotero.d.ts` gains the six methods **and** a `library` accessor (U5). Local acceptance verified against source; **server sync round-trip is the pre-U5 spike**.
+- **OpenAlex:** singleton lookups free; list+filter metered; `mailto` dead; author aggregates currently zeroed but the Works index healthy; `/works?filter=authorships.author.id:{id}` healthy. Header vs query-param key transmission unconfirmed (Open Question); U1 handles both.
+- **`authorships` stays in the fetch selection** (`openalex.ts:255, :262`, `normalizeWork:464-468`).
+- **Additive `CREATE TABLE IF NOT EXISTS`** needs no schema-version machinery (verified: no `ALTER TABLE`/`user_version` in `db.ts`).
+
+## Open Questions (deferred to implementation)
+
+- OpenAlex's actual budget-exhaustion signal (status + header/body discriminator) — required to close U1's `429` mapping.
+- Whether OpenAlex accepts the API key via request header or query param only (U1 handles both; prefer header).
+- Exact `AUTHOR_HINDEX_PAGE_CAP` value (bounds budget for prolific authors; `≥` label applies when hit).
+- Final placement of the confirm/override affordance and the profile↔curation transition within the pane (mockup-gated, U7/U8).
+
+## Sources & Research
+
+- **Local architecture:** additive-tables path and absent column-add path (`src/modules/cache/db.ts:96-111`, `docs/BACKLOG.md`), replicated exhaustiveness gates (`cache/types.ts:189-193, :238-242`), three `cacheWorkData` callsites (`citationService.ts:212, :255`; `citationNetwork/actions.ts:62`), pane lifecycle + XML/CDATA safety (`citationPane.ts:186-589`), rate-limit choke point (`openalex.ts:114-173`), `getResponseHeader` dropped at `openalex.ts:125`, fake-DB coupling (`test/_helpers/fakeDb.ts:112`).
+- **Institutional learnings:** SQLite migration v3 amendments (`docs/plans/2026-05-27-001-feat-sqlite-cache-migration-plan.md`) — composite PKs, two-level orphan GC, ID validation, per-key serialization; column repaint (`project_column_repaint` memory); pane XML safety (`project_pane_bodyxhtml_xml_safety` memory); tokens + gallery parity (`feedback_zotero_css_vars` memory, `test/ui-primitives.test.ts`).
+- **Zotero relations API** (verified against source): methods on `DataObject`; custom predicate must match `^[a-z]+:[a-z]+$`; external URIs stored verbatim and skipped by relation GC; relations sync via item JSON; writes gated on editability. https://www.zotero.org/support/dev/client_coding/javascript_api
+- **OpenAlex Authors API** (verified live 2026-07-16): metered pricing + dropped `mailto` (https://developers.openalex.org/api-reference/authentication); Authors aggregates zeroed while Works healthy; `/works?filter=authorships.author.id:{id}` with cursor paging + `sort`; 301 merges (https://developers.openalex.org/api-reference/errors); author response shape (https://developers.openalex.org/api-reference/authors).

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -91,8 +91,26 @@ export const PREF_LAST_BACKUP_PATH = "extensions.zotero.citegeist.lastBackupPath
 export const PREF_LAST_ORPHAN_GC_AT = "extensions.zotero.citegeist.lastOrphanGcAt";
 export const PREF_CACHE_LIFETIME_DAYS = "extensions.zotero.citegeist.cacheLifetimeDays";
 export const PREF_AUTO_FETCH = "extensions.zotero.citegeist.autoFetch";
+/**
+ * @deprecated OpenAlex dropped the `mailto` polite pool (July 2026). The client
+ * no longer sends it; use {@link PREF_OPENALEX_API_KEY} instead. The pref key is
+ * retained only so the legacy preferences field has a home until U9 removes it.
+ */
 export const PREF_MAILTO = "extensions.zotero.citegeist.mailto";
+/**
+ * Optional, opt-in OpenAlex API key. OpenAlex is metered as of July 2026
+ * ($0.10/day anonymous, $1/day with a free key). Stored locally; never synced;
+ * never logged (redacted via {@link redactApiKey}). Empty/unset → anonymous.
+ */
+export const PREF_OPENALEX_API_KEY = "extensions.zotero.citegeist.openAlexApiKey";
 export const PREF_NETWORK_PAGE_SIZE = "extensions.zotero.citegeist.networkPageSize";
+
+/**
+ * Response header OpenAlex sets to the caller's remaining daily request quota.
+ * A `429` carrying `0` here is budget exhaustion (persistent — prompt for a
+ * key), distinct from a transient per-second rate-limit `429` (retry).
+ */
+export const OPENALEX_RATE_REMAINING_HEADER = "X-RateLimit-Remaining";
 
 /**
  * Settings pane id — registered via `Zotero.PreferencePanes.register` and

--- a/src/modules/cache/authors/db.ts
+++ b/src/modules/cache/authors/db.ts
@@ -1,0 +1,76 @@
+/**
+ * Author-table schema + garbage collection.
+ *
+ * Additive-only: two `CREATE TABLE IF NOT EXISTS` statements run from the
+ * cache's `doInit` (no schema-version gate, no ALTER TABLE — see the plan's
+ * KTD4). There is no in-memory mirror for authors in v1: reads (`read.ts`)
+ * query SQLite asynchronously, which the item pane can do in `onAsyncRender`.
+ */
+
+import { ORPHAN_GC_CHUNK_SIZE } from "../../../constants";
+import type { SqliteBindValue } from "../types";
+
+const AUTHORS_SCHEMA = `
+CREATE TABLE IF NOT EXISTS authors (
+  author_id       TEXT PRIMARY KEY,
+  display_name    TEXT,
+  orcid           TEXT,
+  works_count     INTEGER,
+  cited_by_count  INTEGER,
+  h_index         INTEGER,
+  i10_index       INTEGER,
+  last_fetched    TEXT
+);
+`;
+
+const ITEM_AUTHORS_SCHEMA = `
+CREATE TABLE IF NOT EXISTS item_authors (
+  library_id      INTEGER NOT NULL,
+  item_key        TEXT NOT NULL,
+  author_id       TEXT NOT NULL,
+  author_position INTEGER,
+  is_curated      INTEGER,
+  PRIMARY KEY (library_id, item_key, author_id)
+);
+`;
+
+/**
+ * Create the author tables. Called from the cache's `doInit` after the
+ * `item_cache` schema, on the same connection. Idempotent.
+ */
+export async function createAuthorSchema(conn: _ZoteroTypes.DBConnection): Promise<void> {
+  await conn.queryAsync(AUTHORS_SCHEMA);
+  await conn.queryAsync(ITEM_AUTHORS_SCHEMA);
+}
+
+/**
+ * Two-level orphan sweep, invoked from `garbageCollectOrphans` with the same
+ * orphan set it computed for `item_cache`:
+ *   1. delete `item_authors` rows for items no longer in any library, and
+ *   2. delete `authors` rows left with no referencing `item_authors`.
+ *
+ * Note: curated `item_authors` rows for a genuinely-removed item are deleted
+ * along with the item (the item is gone). This mirrors the item_cache GC's
+ * treatment of non-confirmed rows; author identity re-resolves cheaply on a
+ * later fetch if the item returns.
+ */
+export async function garbageCollectOrphanAuthors(
+  conn: _ZoteroTypes.DBConnection,
+  orphans: ReadonlyArray<{ libraryID: number; itemKey: string }>,
+): Promise<void> {
+  for (let i = 0; i < orphans.length; i += ORPHAN_GC_CHUNK_SIZE) {
+    const slice = orphans.slice(i, i + ORPHAN_GC_CHUNK_SIZE);
+    const tuplePlaceholders = slice.map(() => "(?, ?)").join(",");
+    const params: SqliteBindValue[] = [];
+    for (const o of slice) params.push(o.libraryID, o.itemKey);
+    await conn.queryAsync(
+      `DELETE FROM item_authors WHERE (library_id, item_key) IN (${tuplePlaceholders})`,
+      params,
+    );
+  }
+
+  // Sweep authors no longer referenced by any item_authors row.
+  await conn.queryAsync(
+    `DELETE FROM authors WHERE author_id NOT IN (SELECT DISTINCT author_id FROM item_authors)`,
+  );
+}

--- a/src/modules/cache/authors/index.ts
+++ b/src/modules/cache/authors/index.ts
@@ -1,0 +1,21 @@
+/**
+ * Public surface for the author identity sub-module.
+ *
+ * Internal structure mirrors the parent cache module:
+ *   types.ts  — row shapes, column tuples + compile-time gates, id validation
+ *   db.ts     — schema creation + two-level orphan GC
+ *   read.ts   — async SQLite reads (no sync mirror in v1)
+ *   write.ts  — identity + curation writes under the shared per-key lock
+ */
+
+export type { AuthorRow, ItemAuthorRow } from "./types";
+export { parseAuthorId } from "./types";
+export { createAuthorSchema, garbageCollectOrphanAuthors } from "./db";
+export { getAuthor, getItemAuthors } from "./read";
+export {
+  cacheItemAuthors,
+  setCuratedItemAuthor,
+  updateAuthorMetrics,
+  type CacheAuthorshipInput,
+  type AuthorMetricsInput,
+} from "./write";

--- a/src/modules/cache/authors/read.ts
+++ b/src/modules/cache/authors/read.ts
@@ -1,0 +1,40 @@
+/**
+ * Async read API for author identity.
+ *
+ * No in-memory mirror in v1 (KTD5) — reads query SQLite directly. The item
+ * pane consumes these in `onAsyncRender`, which already awaits, so a sync
+ * mirror isn't needed until authors surface in a sortable column or the v2
+ * "My Authors" index.
+ */
+
+import { requireDb } from "../db";
+import type { AuthorRow, ItemAuthorRow } from "./types";
+
+/**
+ * The item's resolved authors, ordered by their position on the work.
+ * Empty array when the item has no resolved authors yet.
+ */
+export async function getItemAuthors(libraryID: number, itemKey: string): Promise<ItemAuthorRow[]> {
+  const conn = requireDb();
+  const rows = await conn.queryAsync<ItemAuthorRow>(
+    `SELECT library_id, item_key, author_id, author_position, is_curated
+       FROM item_authors
+      WHERE library_id = ? AND item_key = ?
+      ORDER BY author_position`,
+    [libraryID, itemKey],
+  );
+  return rows ?? [];
+}
+
+/** One author by OpenAlex id, or null if not cached. */
+export async function getAuthor(authorId: string): Promise<AuthorRow | null> {
+  const conn = requireDb();
+  const rows = await conn.queryAsync<AuthorRow>(
+    `SELECT author_id, display_name, orcid, works_count, cited_by_count,
+            h_index, i10_index, last_fetched
+       FROM authors
+      WHERE author_id = ?`,
+    [authorId],
+  );
+  return rows && rows.length > 0 ? rows[0] : null;
+}

--- a/src/modules/cache/authors/types.ts
+++ b/src/modules/cache/authors/types.ts
@@ -1,0 +1,116 @@
+/**
+ * Types + column metadata for the author identity tables.
+ *
+ * Mirrors the pattern in `../types.ts`: snake_case row types matching the
+ * SQLite schema verbatim, a frozen `COLUMNS` tuple driving parameter binding,
+ * and two compile-time gates (exhaustiveness + bind-shape). The gates are
+ * hardcoded per row type in `../types.ts` — they do NOT auto-extend to new
+ * tables, so each table below replicates them.
+ *
+ * Two tables:
+ *   • authors      — one row per OpenAlex author (globally-unique `A…` id).
+ *   • item_authors — join: which OpenAlex authors a library item's creators
+ *                    resolve to. Composite PK `(library_id, item_key, author_id)`
+ *                    because Zotero item keys are unique only *within* a library.
+ */
+
+import type { DbBool, SqliteBindValue } from "../types";
+
+// ── authors ────────────────────────────────────────────────────────────────
+
+/** Row mirroring the `authors` schema. Metrics are null until a profile fetch. */
+export interface AuthorRow {
+  author_id: string;
+  display_name: string | null;
+  orcid: string | null;
+  works_count: number | null;
+  cited_by_count: number | null;
+  h_index: number | null;
+  i10_index: number | null;
+  last_fetched: string | null;
+}
+
+export const AUTHOR_COLUMNS = Object.freeze([
+  "author_id",
+  "display_name",
+  "orcid",
+  "works_count",
+  "cited_by_count",
+  "h_index",
+  "i10_index",
+  "last_fetched",
+] as const);
+
+// Compile-time exhaustiveness: adding a field to AuthorRow without adding it
+// to AUTHOR_COLUMNS makes this resolve to `never` and fails the assignment.
+type _AuthorColumnsCovered =
+  Exclude<keyof AuthorRow, (typeof AUTHOR_COLUMNS)[number]> extends never ? true : never;
+const _authorColumnsExhaustive: _AuthorColumnsCovered = true;
+void _authorColumnsExhaustive;
+
+// Compile-time bind-shape: every AuthorRow value must bind to SQLite.
+type _AuthorRowIsBindShape = AuthorRow[keyof AuthorRow] extends SqliteBindValue ? true : never;
+const _authorRowIsBindShape: _AuthorRowIsBindShape = true;
+void _authorRowIsBindShape;
+
+export function authorRowToParams(row: AuthorRow): SqliteBindValue[] {
+  return AUTHOR_COLUMNS.map((c) => row[c]);
+}
+
+// ── item_authors ─────────────────────────────────────────────────────────
+
+/** Row mirroring the `item_authors` schema (the item↔author join). */
+export interface ItemAuthorRow {
+  library_id: number;
+  item_key: string;
+  author_id: string;
+  /** 0-based position of the creator on the work, for ordered display. */
+  author_position: number | null;
+  /** 1 when the user confirmed/overrode this identity (wins over refresh). */
+  is_curated: DbBool;
+}
+
+export const ITEM_AUTHOR_COLUMNS = Object.freeze([
+  "library_id",
+  "item_key",
+  "author_id",
+  "author_position",
+  "is_curated",
+] as const);
+
+type _ItemAuthorColumnsCovered =
+  Exclude<keyof ItemAuthorRow, (typeof ITEM_AUTHOR_COLUMNS)[number]> extends never ? true : never;
+const _itemAuthorColumnsExhaustive: _ItemAuthorColumnsCovered = true;
+void _itemAuthorColumnsExhaustive;
+
+type _ItemAuthorRowIsBindShape = ItemAuthorRow[keyof ItemAuthorRow] extends SqliteBindValue
+  ? true
+  : never;
+const _itemAuthorRowIsBindShape: _ItemAuthorRowIsBindShape = true;
+void _itemAuthorRowIsBindShape;
+
+export function itemAuthorRowToParams(row: ItemAuthorRow): SqliteBindValue[] {
+  return ITEM_AUTHOR_COLUMNS.map((c) => row[c]);
+}
+
+// ── Validation ─────────────────────────────────────────────────────────────
+
+/**
+ * OpenAlex author ID: literal `A` followed by 1–20 digits. Length-bounded so
+ * a compromised/MITM'd response can't push an arbitrarily long value into a
+ * SQLite key and a synced Zotero relation URI. Real OpenAlex ids are ~10 digits.
+ */
+const OPEN_ALEX_AUTHOR_ID_RE = /^A\d{1,20}$/;
+const OPEN_ALEX_URL_PREFIX = "https://openalex.org/";
+
+/**
+ * Strip the OpenAlex URL prefix and validate the resulting author ID.
+ * Returns null for anything that doesn't match `/^A\d{1,20}$/` — callers must
+ * treat null as "reject this authorship" since a malformed id would otherwise
+ * become a primary key and a synced relation URI.
+ */
+export function parseAuthorId(raw: string | null | undefined): string | null {
+  if (!raw) return null;
+  const id = raw.replace(OPEN_ALEX_URL_PREFIX, "");
+  return OPEN_ALEX_AUTHOR_ID_RE.test(id) ? id : null;
+}

--- a/src/modules/cache/authors/write.ts
+++ b/src/modules/cache/authors/write.ts
@@ -1,0 +1,165 @@
+/**
+ * Async write API for author identity.
+ *
+ * Concurrency: writes that touch a given item's `item_authors` rows run under
+ * the cache's shared per-`(libraryID, itemKey)` lock (`withKeyLock`, exported
+ * from `../db`). Sharing the lock — rather than a second parallel lock — means
+ * a background identity write and a user override for the same item serialize
+ * against each other AND against the item's `item_cache` write, and all of them
+ * participate in the `closeCache` drain.
+ *
+ * Author-row writes are split into column-disjoint statements so they never
+ * clobber each other: the identity path (`INSERT OR IGNORE` + `UPDATE` of
+ * display_name/orcid) leaves the metric columns untouched, and the metric path
+ * (U6 profile fetch) updates only metric columns. No read-modify-write of the
+ * shared author row is required, so cross-item author writes are safe without a
+ * dedicated author-id lock.
+ */
+
+import { requireDb, withKeyLock } from "../db";
+import type { CacheItemKey } from "../types";
+import { parseAuthorId } from "./types";
+
+/** Minimum authorship shape the cache consumes — structurally a subset of
+ * `OpenAlexWork["authorships"][number]`, so callers pass those directly. */
+export interface CacheAuthorshipInput {
+  author: {
+    id: string;
+    display_name?: string;
+    orcid?: string | null;
+  };
+}
+
+/** Derived author metrics written by the profile fetch (U6). */
+export interface AuthorMetricsInput {
+  worksCount: number | null;
+  citedByCount: number | null;
+  hIndex: number | null;
+  i10Index: number | null;
+  lastFetched: string;
+}
+
+/** Ensure the author row exists, then set identity fields only (metric-preserving). */
+async function upsertAuthorIdentity(
+  conn: _ZoteroTypes.DBConnection,
+  authorId: string,
+  displayName: string | null,
+  orcid: string | null,
+): Promise<void> {
+  await conn.queryAsync(`INSERT OR IGNORE INTO authors (author_id) VALUES (?)`, [authorId]);
+  await conn.queryAsync(`UPDATE authors SET display_name = ?, orcid = ? WHERE author_id = ?`, [
+    displayName,
+    orcid,
+    authorId,
+  ]);
+}
+
+/**
+ * Resolve and persist a library item's authors from a fetched work's
+ * authorships. Free-riding the metrics fetch (KTD9): callers invoke this right
+ * after `cacheWorkData`, where the `work` (and its authorships) is in hand.
+ *
+ * Curated rows (`is_curated = 1`) are never overwritten — the user's confirmed
+ * identity wins over a later background refresh (KTD7 / AE1). All of it runs
+ * inside the per-item lock so a concurrent override can't be clobbered.
+ */
+export async function cacheItemAuthors(
+  item: CacheItemKey,
+  authorships: ReadonlyArray<CacheAuthorshipInput>,
+): Promise<void> {
+  const { libraryID, key: itemKey } = item;
+
+  // Validate + order at the trust boundary. Position is the array index
+  // (OpenAlex's `author_position` is "first"/"middle"/"last", not an index).
+  const valid: Array<{ id: string; position: number; name: string | null; orcid: string | null }> =
+    [];
+  const seen = new Set<string>();
+  authorships.forEach((a, idx) => {
+    const id = parseAuthorId(a.author?.id);
+    if (!id || seen.has(id)) return;
+    seen.add(id);
+    valid.push({
+      id,
+      position: idx,
+      name: a.author.display_name ?? null,
+      orcid: a.author.orcid ?? null,
+    });
+  });
+
+  await withKeyLock(libraryID, itemKey, async () => {
+    const conn = requireDb();
+
+    for (const v of valid) {
+      await upsertAuthorIdentity(conn, v.id, v.name, v.orcid);
+    }
+
+    // Preserve curated rows; replace the rest.
+    const existing = await conn.queryAsync<{ author_id: string; is_curated: 0 | 1 | null }>(
+      `SELECT author_id, is_curated FROM item_authors WHERE library_id = ? AND item_key = ?`,
+      [libraryID, itemKey],
+    );
+    const curated = new Set(
+      (existing ?? []).filter((r) => r.is_curated === 1).map((r) => r.author_id),
+    );
+
+    await conn.queryAsync(
+      `DELETE FROM item_authors WHERE library_id = ? AND item_key = ? AND (is_curated IS NULL OR is_curated != 1)`,
+      [libraryID, itemKey],
+    );
+
+    for (const v of valid) {
+      if (curated.has(v.id)) continue; // don't downgrade a curated identity
+      await conn.queryAsync(
+        `INSERT OR REPLACE INTO item_authors (library_id, item_key, author_id, author_position, is_curated) VALUES (?, ?, ?, ?, ?)`,
+        [libraryID, itemKey, v.id, v.position, 0],
+      );
+    }
+  });
+}
+
+/**
+ * Record a user-confirmed/overridden author identity for a creator position on
+ * an item. Stored as `is_curated = 1` so future background refreshes preserve
+ * it. Storage primitive for the U8 curation UI.
+ */
+export async function setCuratedItemAuthor(
+  item: CacheItemKey,
+  authorId: string,
+  position: number | null,
+): Promise<void> {
+  const id = parseAuthorId(authorId);
+  if (!id) return;
+  await withKeyLock(item.libraryID, item.key, async () => {
+    const conn = requireDb();
+    await conn.queryAsync(`INSERT OR IGNORE INTO authors (author_id) VALUES (?)`, [id]);
+    await conn.queryAsync(
+      `INSERT OR REPLACE INTO item_authors (library_id, item_key, author_id, author_position, is_curated) VALUES (?, ?, ?, ?, ?)`,
+      [item.libraryID, item.key, id, position, 1],
+    );
+  });
+}
+
+/**
+ * Write derived author metrics (from the profile fetch, U6). Column-disjoint
+ * from the identity path so the two never clobber. Ensures the row exists.
+ */
+export async function updateAuthorMetrics(
+  authorId: string,
+  metrics: AuthorMetricsInput,
+): Promise<void> {
+  const id = parseAuthorId(authorId);
+  if (!id) return;
+  const conn = requireDb();
+  await conn.queryAsync(`INSERT OR IGNORE INTO authors (author_id) VALUES (?)`, [id]);
+  await conn.queryAsync(
+    `UPDATE authors SET works_count = ?, cited_by_count = ?, h_index = ?, i10_index = ?, last_fetched = ? WHERE author_id = ?`,
+    [
+      metrics.worksCount,
+      metrics.citedByCount,
+      metrics.hIndex,
+      metrics.i10Index,
+      metrics.lastFetched,
+      id,
+    ],
+  );
+}

--- a/src/modules/cache/db.ts
+++ b/src/modules/cache/db.ts
@@ -18,6 +18,7 @@
 
 import { CLOSE_CACHE_DRAIN_TIMEOUT_MS } from "../../constants";
 import { COLUMNS, type ItemCacheRow, mirrorKey, rowToParams } from "./types";
+import { createAuthorSchema } from "./authors/db";
 
 /** Pre-computed UPSERT statement. `COLUMNS` is frozen, so this stays valid. */
 const UPSERT_SQL = `INSERT OR REPLACE INTO item_cache (${COLUMNS.join(", ")}) VALUES (${COLUMNS.map(
@@ -100,6 +101,9 @@ async function doInit(): Promise<void> {
   const conn = new Zotero.DBConnection("citegeist");
   await conn.queryAsync(SCHEMA);
   await conn.queryAsync(CREATE_PROGRESS_TABLE);
+  // Author identity tables (additive, idempotent — plan KTD4). No mirror is
+  // loaded for them: author reads query SQLite async in the pane.
+  await createAuthorSchema(conn);
 
   const rows = await conn.queryAsync<ItemCacheRow>(`SELECT * FROM item_cache`);
   const nextMirror = new Map(rows.map((r) => [mirrorKey(r.library_id, r.item_key), r]));
@@ -227,7 +231,7 @@ const noop = (): void => {};
  * Map would grow monotonically with the count of distinct keys ever
  * written, leaking memory under sustained workloads.
  */
-async function withKeyLock<T>(
+export async function withKeyLock<T>(
   libraryID: number,
   itemKey: string,
   fn: () => Promise<T>,
@@ -283,6 +287,13 @@ export async function deleteRow(libraryID: number, itemKey: string): Promise<voi
     // by `shouldForceRerun` would skip the now-empty row at checkpoint
     // lookup and the user's intentional clear would not trigger re-migration.
     await conn.queryAsync(`DELETE FROM migration_progress WHERE library_id = ? AND item_key = ?`, [
+      libraryID,
+      itemKey,
+    ]);
+    // Drop the item's resolved-author links too (per-item author GC). The
+    // library-wide sweep for items removed while Zotero was closed rides
+    // garbageCollectOrphans → garbageCollectOrphanAuthors.
+    await conn.queryAsync(`DELETE FROM item_authors WHERE library_id = ? AND item_key = ?`, [
       libraryID,
       itemKey,
     ]);

--- a/src/modules/cache/index.ts
+++ b/src/modules/cache/index.ts
@@ -56,3 +56,14 @@ export {
 
 // ── Data hygiene ──
 export { garbageCollectOrphans, migrateFromExtraV1 } from "./migration";
+
+// ── Author identity ──
+export type { AuthorRow, ItemAuthorRow } from "./authors";
+export {
+  cacheItemAuthors,
+  getAuthor,
+  getItemAuthors,
+  parseAuthorId,
+  setCuratedItemAuthor,
+  updateAuthorMetrics,
+} from "./authors";

--- a/src/modules/cache/migration.ts
+++ b/src/modules/cache/migration.ts
@@ -28,6 +28,7 @@ import {
 import { logError, normalizeError, safeParseFloat, safeParseIntOrNull } from "../utils";
 import { deleteMirrorEntries, mirrorSnapshot, requireDb, upsertRow } from "./db";
 import { setExtraConfirmedMatch } from "./write";
+import { garbageCollectOrphanAuthors } from "./authors/db";
 import {
   CONFIRMED_MATCH_EXTRA_PREFIX,
   emptyRow,
@@ -951,6 +952,9 @@ export async function garbageCollectOrphans(options: { force?: boolean } = {}): 
     );
     deleteMirrorEntries(slice.map((o) => o.composite));
   }
+  // Two-level author sweep on the same orphan set: drop their item_authors
+  // rows, then any authors left unreferenced.
+  await garbageCollectOrphanAuthors(conn, orphans);
   trySetPref(PREF_LAST_ORPHAN_GC_AT, Date.now());
   Zotero.debug(`[Citegeist] orphan GC removed ${orphans.length} rows`);
 }

--- a/src/modules/openalex.ts
+++ b/src/modules/openalex.ts
@@ -1,25 +1,37 @@
 /**
  * OpenAlex API client for Citegeist.
  *
- * Uses Zotero.HTTP for requests. Implements polite pool via mailto,
- * field selection for minimal payloads, and cursor-based pagination.
+ * Uses Zotero.HTTP for requests, field selection for minimal payloads, and
+ * cursor-based pagination.
+ *
+ * Auth + budget (July 2026): OpenAlex is metered and has dropped the `mailto`
+ * polite pool. An optional, opt-in API key is attached from the pref when set;
+ * it is never logged (redacted centrally in {@link normalizeError}). Anonymous
+ * requests still work at the lower daily budget.
  *
  * Error semantics: lookup helpers return `null` when a work is not found
- * on OpenAlex, and throw {@link OpenAlexNetworkError} when the API is
- * unreachable or returns a non-200 after retries. This lets callers
- * distinguish "no data" from "service unavailable" to render a helpful
- * message to users.
+ * (404). Otherwise the fetch layer throws one of three distinct errors so UI
+ * can respond appropriately: {@link OpenAlexBudgetError} (daily budget spent —
+ * prompt for a key), {@link OpenAlexAuthError} (key rejected), or
+ * {@link OpenAlexNetworkError} (unreachable / non-200 after retries).
  */
 
 import {
   OPENALEX_RATE_LIMIT_MS,
   OPENALEX_REQUEST_TIMEOUT_MS,
   OPENALEX_RETRY_DELAYS_MS,
+  OPENALEX_RATE_REMAINING_HEADER,
   MAX_ABSTRACT_LENGTH,
   MAX_ABSTRACT_POSITION,
-  PREF_MAILTO,
+  PREF_OPENALEX_API_KEY,
 } from "../constants";
-import { OpenAlexNetworkError, normalizeError, logError } from "./utils";
+import {
+  OpenAlexNetworkError,
+  OpenAlexBudgetError,
+  OpenAlexAuthError,
+  normalizeError,
+  logError,
+} from "./utils";
 
 const OPENALEX_BASE = "https://api.openalex.org";
 
@@ -87,24 +99,44 @@ export interface OpenAlexListResponse {
   results: OpenAlexWork[];
 }
 
-function getMailto(): string {
+/**
+ * Read the optional OpenAlex API key from prefs. Empty string when unset —
+ * anonymous requests remain valid (at the lower daily budget).
+ */
+function getApiKey(): string {
   try {
-    const mailto = Zotero.Prefs.get(PREF_MAILTO) as string;
-    return mailto || "";
+    const key = Zotero.Prefs.get(PREF_OPENALEX_API_KEY) as string;
+    return (key || "").trim();
   } catch {
     return "";
   }
 }
 
 function buildUrl(path: string, params: Record<string, string> = {}): string {
-  const mailto = getMailto();
-  if (mailto) {
-    params.mailto = mailto;
+  // The key rides the query string (OpenAlex's documented mechanism as of
+  // July 2026 — a header form is an open question). It is never logged: the
+  // retry/error paths log `label`, not the URL, and normalizeError() redacts
+  // any URL that reaches it. Prefer a header here if OpenAlex confirms one.
+  const apiKey = getApiKey();
+  if (apiKey) {
+    params.api_key = apiKey;
   }
   const query = Object.entries(params)
     .map(([k, v]) => `${encodeURIComponent(k)}=${encodeURIComponent(v)}`)
     .join("&");
   return `${OPENALEX_BASE}${path}${query ? "?" + query : ""}`;
+}
+
+/**
+ * OpenAlex churns author/entity IDs and 301-redirects a merged ID to its
+ * survivor. Zotero.HTTP follows the redirect, but the requested ID may no
+ * longer be canonical — persist the `id` the response body actually carries.
+ * Returns the short form (`A123`/`W123`) or null if absent/malformed.
+ */
+export function resolveCanonicalId(body: { id?: string | null } | null | undefined): string | null {
+  const raw = body?.id;
+  if (typeof raw !== "string" || !raw) return null;
+  return raw.replace("https://openalex.org/", "") || null;
 }
 
 // ── Centralized rate limiter ──
@@ -122,12 +154,16 @@ async function rateLimitedFetch<T>(url: string, label: string, attempt = 0): Pro
 }
 
 async function fetchJson<T>(url: string, label: string, attempt: number): Promise<T> {
-  let response: { status: number; responseText: string };
+  let response: {
+    status: number;
+    responseText: string;
+    getResponseHeader?: (name: string) => string | null;
+  };
   try {
     response = await Zotero.HTTP.request("GET", url, {
       headers: {
         Accept: "application/json",
-        "User-Agent": `Citegeist/1.0 (Zotero plugin; ${getMailto() || "no-mailto"})`,
+        "User-Agent": "Citegeist/1.0 (Zotero plugin)",
       },
       responseType: "text",
       timeout: OPENALEX_REQUEST_TIMEOUT_MS,
@@ -145,7 +181,26 @@ async function fetchJson<T>(url: string, label: string, attempt: number): Promis
     throw new OpenAlexNetworkError(`OpenAlex unreachable while fetching ${label}`, e);
   }
 
-  // Retry with backoff on rate limiting / transient 5xx.
+  // Auth failure (bad/revoked key) — distinct so the UI can prompt re-entry.
+  if (response.status === 401 || response.status === 403) {
+    throw new OpenAlexAuthError(
+      `OpenAlex rejected the request for ${label} (HTTP ${response.status})`,
+    );
+  }
+
+  // A 429 is overloaded: daily-budget exhaustion (persistent — prompt for a
+  // key, do NOT retry) vs a transient per-second rate limit (retry). The
+  // remaining-quota header at exactly "0" is the budget-exhaustion signal.
+  // (The precise budget signal is pending live confirmation — see plan Open
+  // Questions; this discriminator is isolated here for easy adjustment.)
+  if (response.status === 429) {
+    const remaining = response.getResponseHeader?.(OPENALEX_RATE_REMAINING_HEADER);
+    if (typeof remaining === "string" && remaining.trim() === "0") {
+      throw new OpenAlexBudgetError(`OpenAlex daily budget exhausted while fetching ${label}`);
+    }
+  }
+
+  // Retry with backoff on transient rate limiting / 5xx.
   if (
     (response.status === 429 || response.status >= 500) &&
     attempt < OPENALEX_RETRY_DELAYS_MS.length

--- a/src/modules/utils.ts
+++ b/src/modules/utils.ts
@@ -73,13 +73,32 @@ export function safeParseFloat(val: string | undefined): number | null {
 }
 
 /**
+ * Redact an OpenAlex `api_key` query-param value from any string.
+ *
+ * OpenAlex is metered (July 2026); the optional key rides the request URL as
+ * `?api_key=…`. Zotero.HTTP errors can carry the full URL in their message, so
+ * every string bound for a log MUST pass through here. This is centralized
+ * inside {@link normalizeError} — the single funnel every `logError` and raw
+ * `Zotero.debug(normalizeError(e))` call already uses — rather than at
+ * individual call sites, so no logging path can bypass it.
+ */
+export function redactApiKey(s: string): string {
+  return s.replace(/(\bapi_key=)[^&\s"')]+/gi, "$1REDACTED");
+}
+
+/**
  * Normalize an unknown caught value into a string suitable for logging.
  *
  * Zotero.debug(msg + e) coerces objects to "[object Object]" and drops
  * stack traces. Use this helper in every catch() so log lines are useful
- * in production.
+ * in production. The result is always run through {@link redactApiKey} so a
+ * URL-bearing error can never leak the user's OpenAlex key into the debug log.
  */
 export function normalizeError(e: unknown): string {
+  return redactApiKey(rawNormalizeError(e));
+}
+
+function rawNormalizeError(e: unknown): string {
   if (e instanceof Error) {
     const first = e.stack?.split("\n")[1]?.trim();
     return first ? `${e.message} (${first})` : e.message;
@@ -120,6 +139,30 @@ export class OpenAlexNetworkError extends Error {
   ) {
     super(message);
     this.name = "OpenAlexNetworkError";
+  }
+}
+
+/**
+ * The caller's OpenAlex daily budget is exhausted (July-2026 metered API).
+ * Distinct from {@link OpenAlexNetworkError} so the UI can prompt the user to
+ * add an API key rather than showing an "unreachable" dead end, and so a
+ * bulk pass can stop cleanly instead of caching a spurious "no data".
+ */
+export class OpenAlexBudgetError extends Error {
+  constructor(message = "OpenAlex daily budget exhausted") {
+    super(message);
+    this.name = "OpenAlexBudgetError";
+  }
+}
+
+/**
+ * OpenAlex rejected the request's API key (HTTP 401/403). Distinct from a
+ * network failure so the UI can prompt the user to re-check their key.
+ */
+export class OpenAlexAuthError extends Error {
+  constructor(message = "OpenAlex rejected the API key") {
+    super(message);
+    this.name = "OpenAlexAuthError";
   }
 }
 

--- a/test/_helpers/fakeDb.ts
+++ b/test/_helpers/fakeDb.ts
@@ -2,8 +2,9 @@
  * Shared in-memory fake of `Zotero.DBConnection` for cache-module tests.
  *
  * Decodes the SQL the cache module actually emits — composite-keyed
- * INSERT/SELECT/DELETE against `item_cache` plus the `migration_progress`
- * lifecycle. Throws on anything else so a missing handler surfaces loudly.
+ * INSERT/SELECT/DELETE against `item_cache`, the `migration_progress`
+ * lifecycle, and the `authors` / `item_authors` identity tables. Throws on
+ * anything else so a missing handler surfaces loudly.
  */
 
 import { vi } from "vitest";
@@ -16,34 +17,59 @@ export function compositeKey(libraryID: number | string, itemKey: string): strin
   return `${libraryID}:${itemKey}`;
 }
 
+function itemAuthorKey(lib: number | string, key: string, authorId: string): string {
+  return `${lib}:${key}:${authorId}`;
+}
+
 export function makeFakeDb() {
   // Composite-keyed (`${library_id}:${item_key}`) maps mirroring SQLite.
   const table = new Map<string, FakeRow>();
   const progress = new Map<string, string>();
+  // author_id → row
+  const authors = new Map<string, FakeRow>();
+  // `${library_id}:${item_key}:${author_id}` → row
+  const itemAuthors = new Map<string, FakeRow>();
+
+  function emptyAuthor(authorId: string): FakeRow {
+    return {
+      author_id: authorId,
+      display_name: null,
+      orcid: null,
+      works_count: null,
+      cited_by_count: null,
+      h_index: null,
+      i10_index: null,
+      last_fetched: null,
+    };
+  }
 
   return {
     table,
     progress,
+    authors,
+    itemAuthors,
     queryAsync: vi.fn(async (sql: string, params?: unknown[]) => {
       const s = sql.trim();
+      const p = (params ?? []) as unknown[];
 
       if (/^CREATE\s+(TABLE|INDEX)/i.test(s)) return [];
       if (/^DROP\s+INDEX/i.test(s)) return [];
 
+      // ── item_cache ──
       if (/^INSERT\s+OR\s+REPLACE\s+INTO\s+item_cache/i.test(s)) {
         const colsMatch = /\(([^)]+)\)\s+VALUES/i.exec(s);
         if (!colsMatch) throw new Error("bad INSERT statement: " + s);
         const cols = colsMatch[1].split(",").map((c) => c.trim());
         const row: FakeRow = {};
         cols.forEach((c, i) => {
-          row[c] = params?.[i] ?? null;
+          row[c] = p[i] ?? null;
         });
         table.set(compositeKey(row.library_id as number, row.item_key as string), row);
         return [];
       }
 
       if (/^INSERT\s+OR\s+REPLACE\s+INTO\s+migration_progress/i.test(s)) {
-        const [libId, key, at] = params as [number, string, string];
+        const [libId, key, at] = p as [number, string, string];
         progress.set(compositeKey(libId, key), at);
         return [];
       }
@@ -62,7 +88,7 @@ export function makeFakeDb() {
       }
 
       if (/^SELECT\s+item_key\s+FROM\s+migration_progress/i.test(s)) {
-        const [libId, key] = params as [number, string];
+        const [libId, key] = p as [number, string];
         return progress.has(compositeKey(libId, key)) ? [{ item_key: key }] : [];
       }
 
@@ -71,13 +97,12 @@ export function makeFakeDb() {
           s,
         )
       ) {
-        const [libId, key] = params as [number, string];
+        const [libId, key] = p as [number, string];
         table.delete(compositeKey(libId, key));
         return [];
       }
 
       if (/^DELETE\s+FROM\s+item_cache\s+WHERE\s+\(library_id,\s+item_key\)\s+IN/i.test(s)) {
-        const p = (params ?? []) as Array<number | string>;
         for (let i = 0; i < p.length; i += 2) {
           table.delete(compositeKey(p[i] as number, p[i + 1] as string));
         }
@@ -87,7 +112,6 @@ export function makeFakeDb() {
       if (
         /^DELETE\s+FROM\s+migration_progress\s+WHERE\s+\(library_id,\s+item_key\)\s+IN/i.test(s)
       ) {
-        const p = (params ?? []) as Array<number | string>;
         for (let i = 0; i < p.length; i += 2) {
           progress.delete(compositeKey(p[i] as number, p[i + 1] as string));
         }
@@ -99,13 +123,134 @@ export function makeFakeDb() {
           s,
         )
       ) {
-        const [libId, key] = params as [number, string];
+        const [libId, key] = p as [number, string];
         progress.delete(compositeKey(libId, key));
         return [];
       }
 
       if (/^DELETE\s+FROM\s+migration_progress\s*$/i.test(s)) {
         progress.clear();
+        return [];
+      }
+
+      // ── authors ──
+      if (/^INSERT\s+OR\s+IGNORE\s+INTO\s+authors/i.test(s)) {
+        const [authorId] = p as [string];
+        if (!authors.has(authorId)) authors.set(authorId, emptyAuthor(authorId));
+        return [];
+      }
+
+      if (/^UPDATE\s+authors\s+SET\s+display_name\s*=\s*\?,\s*orcid\s*=\s*\?\s+WHERE/i.test(s)) {
+        const [displayName, orcid, authorId] = p as [string | null, string | null, string];
+        const row = authors.get(authorId);
+        if (row) {
+          row.display_name = displayName;
+          row.orcid = orcid;
+        }
+        return [];
+      }
+
+      if (/^UPDATE\s+authors\s+SET\s+works_count/i.test(s)) {
+        const [wc, cc, h, i10, lf, authorId] = p as [
+          number | null,
+          number | null,
+          number | null,
+          number | null,
+          string | null,
+          string,
+        ];
+        const row = authors.get(authorId);
+        if (row) {
+          row.works_count = wc;
+          row.cited_by_count = cc;
+          row.h_index = h;
+          row.i10_index = i10;
+          row.last_fetched = lf;
+        }
+        return [];
+      }
+
+      if (/^SELECT[\s\S]*FROM\s+authors\s+WHERE\s+author_id\s*=\s*\?/i.test(s)) {
+        const [authorId] = p as [string];
+        const row = authors.get(authorId);
+        return row ? [row] : [];
+      }
+
+      if (/^DELETE\s+FROM\s+authors\s+WHERE\s+author_id\s+NOT\s+IN/i.test(s)) {
+        const referenced = new Set<string>();
+        for (const r of itemAuthors.values()) referenced.add(r.author_id as string);
+        for (const id of [...authors.keys()]) {
+          if (!referenced.has(id)) authors.delete(id);
+        }
+        return [];
+      }
+
+      // ── item_authors ──
+      if (/^INSERT\s+OR\s+REPLACE\s+INTO\s+item_authors/i.test(s)) {
+        const colsMatch = /\(([^)]+)\)\s+VALUES/i.exec(s);
+        if (!colsMatch) throw new Error("bad INSERT statement: " + s);
+        const cols = colsMatch[1].split(",").map((c) => c.trim());
+        const row: FakeRow = {};
+        cols.forEach((c, i) => {
+          row[c] = p[i] ?? null;
+        });
+        itemAuthors.set(
+          itemAuthorKey(row.library_id as number, row.item_key as string, row.author_id as string),
+          row,
+        );
+        return [];
+      }
+
+      if (/^SELECT\s+author_id,\s*is_curated\s+FROM\s+item_authors/i.test(s)) {
+        const [lib, key] = p as [number, string];
+        return [...itemAuthors.values()]
+          .filter((r) => r.library_id === lib && r.item_key === key)
+          .map((r) => ({ author_id: r.author_id, is_curated: r.is_curated }));
+      }
+
+      if (/^SELECT[\s\S]*FROM\s+item_authors[\s\S]*ORDER\s+BY\s+author_position/i.test(s)) {
+        const [lib, key] = p as [number, string];
+        return [...itemAuthors.values()]
+          .filter((r) => r.library_id === lib && r.item_key === key)
+          .sort(
+            (a, b) => ((a.author_position as number) ?? 0) - ((b.author_position as number) ?? 0),
+          );
+      }
+
+      if (
+        /^DELETE\s+FROM\s+item_authors\s+WHERE\s+library_id\s*=\s*\?\s+AND\s+item_key\s*=\s*\?\s+AND\s+\(is_curated/i.test(
+          s,
+        )
+      ) {
+        const [lib, key] = p as [number, string];
+        for (const [k, r] of [...itemAuthors.entries()]) {
+          if (r.library_id === lib && r.item_key === key && r.is_curated !== 1)
+            itemAuthors.delete(k);
+        }
+        return [];
+      }
+
+      if (
+        /^DELETE\s+FROM\s+item_authors\s+WHERE\s+library_id\s*=\s*\?\s+AND\s+item_key\s*=\s*\?\s*$/i.test(
+          s,
+        )
+      ) {
+        const [lib, key] = p as [number, string];
+        for (const [k, r] of [...itemAuthors.entries()]) {
+          if (r.library_id === lib && r.item_key === key) itemAuthors.delete(k);
+        }
+        return [];
+      }
+
+      if (/^DELETE\s+FROM\s+item_authors\s+WHERE\s+\(library_id,\s*item_key\)\s+IN/i.test(s)) {
+        const pairs = new Set<string>();
+        for (let i = 0; i < p.length; i += 2)
+          pairs.add(compositeKey(p[i] as number, p[i + 1] as string));
+        for (const [k, r] of [...itemAuthors.entries()]) {
+          if (pairs.has(compositeKey(r.library_id as number, r.item_key as string))) {
+            itemAuthors.delete(k);
+          }
+        }
         return [];
       }
 

--- a/test/authorCache.test.ts
+++ b/test/authorCache.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Tests for the U2 author cache sub-module: schema, identity persistence,
+ * curated-wins preservation (AE1), concurrency under the shared per-key lock,
+ * metric-preserving writes, and two-level orphan GC.
+ */
+import { describe, it, expect, beforeEach } from "vitest";
+import { resetCacheHarness, fakeDb } from "./_helpers/cacheHarness";
+import { initCache, _resetForTesting, deleteRow } from "../src/modules/cache/db";
+import {
+  cacheItemAuthors,
+  getItemAuthors,
+  getAuthor,
+  setCuratedItemAuthor,
+  updateAuthorMetrics,
+  garbageCollectOrphanAuthors,
+  type CacheAuthorshipInput,
+} from "../src/modules/cache/authors";
+
+function authorship(
+  id: string,
+  name = "Author " + id,
+  orcid: string | null = null,
+): CacheAuthorshipInput {
+  return { author: { id, display_name: name, orcid } };
+}
+
+const ITEM = { libraryID: 1, key: "ITEMKEY1" };
+
+beforeEach(async () => {
+  await resetCacheHarness(initCache, _resetForTesting);
+});
+
+describe("cacheItemAuthors", () => {
+  it("persists item_authors rows (ordered) and author identity rows", async () => {
+    await cacheItemAuthors(ITEM, [authorship("A1", "Alice", "0000-1"), authorship("A2", "Bob")]);
+
+    const rows = await getItemAuthors(1, "ITEMKEY1");
+    expect(rows.map((r) => r.author_id)).toEqual(["A1", "A2"]);
+    expect(rows.map((r) => r.author_position)).toEqual([0, 1]);
+    expect(rows.every((r) => r.is_curated === 0)).toBe(true);
+
+    const a1 = await getAuthor("A1");
+    expect(a1?.display_name).toBe("Alice");
+    expect(a1?.orcid).toBe("0000-1");
+  });
+
+  it("rejects malformed author ids at the trust boundary", async () => {
+    await cacheItemAuthors(ITEM, [
+      authorship("A1", "Valid"),
+      authorship("W123", "AWorkId"),
+      authorship("Axyz", "NotDigits"),
+      { author: { id: "https://openalex.org/A5", display_name: "Prefixed" } },
+    ]);
+    const rows = await getItemAuthors(1, "ITEMKEY1");
+    expect(rows.map((r) => r.author_id).sort()).toEqual(["A1", "A5"]);
+  });
+
+  it("keeps the same item key in two libraries distinct", async () => {
+    await cacheItemAuthors({ libraryID: 1, key: "K" }, [authorship("A1")]);
+    await cacheItemAuthors({ libraryID: 2, key: "K" }, [authorship("A2")]);
+    expect((await getItemAuthors(1, "K")).map((r) => r.author_id)).toEqual(["A1"]);
+    expect((await getItemAuthors(2, "K")).map((r) => r.author_id)).toEqual(["A2"]);
+  });
+
+  it("preserves a curated identity across a background refresh (AE1)", async () => {
+    await cacheItemAuthors(ITEM, [authorship("A1"), authorship("A2")]);
+    await setCuratedItemAuthor(ITEM, "A3", 5);
+
+    // Background refresh with a different author set that omits the curated one.
+    await cacheItemAuthors(ITEM, [authorship("A2")]);
+
+    const rows = await getItemAuthors(1, "ITEMKEY1");
+    const byId = new Map(rows.map((r) => [r.author_id, r]));
+    expect(byId.get("A3")?.is_curated).toBe(1); // curated survives
+    expect(byId.has("A2")).toBe(true); // non-curated re-added
+    expect(byId.has("A1")).toBe(false); // stale non-curated dropped
+  });
+
+  it("does not downgrade a curated author present in the refresh set", async () => {
+    await setCuratedItemAuthor(ITEM, "A1", 0);
+    await cacheItemAuthors(ITEM, [authorship("A1"), authorship("A2")]);
+    const rows = await getItemAuthors(1, "ITEMKEY1");
+    expect(rows.find((r) => r.author_id === "A1")?.is_curated).toBe(1);
+    expect(rows.find((r) => r.author_id === "A2")?.is_curated).toBe(0);
+  });
+
+  it("curated wins when an override races a background write (shared lock)", async () => {
+    await Promise.all([
+      cacheItemAuthors(ITEM, [authorship("A1")]),
+      setCuratedItemAuthor(ITEM, "A1", 0),
+    ]);
+    const rows = await getItemAuthors(1, "ITEMKEY1");
+    expect(rows).toHaveLength(1);
+    expect(rows[0].is_curated).toBe(1);
+  });
+});
+
+describe("author metrics", () => {
+  it("identity writes preserve previously-derived metric columns", async () => {
+    await cacheItemAuthors(ITEM, [authorship("A1", "Alice")]);
+    await updateAuthorMetrics("A1", {
+      worksCount: 42,
+      citedByCount: 999,
+      hIndex: 20,
+      i10Index: 30,
+      lastFetched: "2026-07-16",
+    });
+    // A later identity-only write (background refresh) must not null metrics.
+    await cacheItemAuthors(ITEM, [authorship("A1", "Alice B. Smith")]);
+
+    const a1 = await getAuthor("A1");
+    expect(a1?.display_name).toBe("Alice B. Smith"); // identity updated
+    expect(a1?.works_count).toBe(42); // metrics preserved
+    expect(a1?.h_index).toBe(20);
+  });
+});
+
+describe("orphan GC", () => {
+  it("deleteRow drops the item's item_authors", async () => {
+    await cacheItemAuthors(ITEM, [authorship("A1"), authorship("A2")]);
+    await deleteRow(1, "ITEMKEY1");
+    expect(await getItemAuthors(1, "ITEMKEY1")).toHaveLength(0);
+  });
+
+  it("two-level sweep removes orphaned item_authors then unreferenced authors", async () => {
+    await cacheItemAuthors({ libraryID: 1, key: "GONE" }, [authorship("A1")]);
+    await cacheItemAuthors({ libraryID: 1, key: "STAY" }, [authorship("A2")]);
+
+    await garbageCollectOrphanAuthors(fakeDb as unknown as _ZoteroTypes.DBConnection, [
+      { libraryID: 1, itemKey: "GONE" },
+    ]);
+
+    expect(await getItemAuthors(1, "GONE")).toHaveLength(0);
+    expect(await getItemAuthors(1, "STAY")).toHaveLength(1);
+    expect(await getAuthor("A1")).toBeNull(); // orphaned author swept
+    expect(await getAuthor("A2")).not.toBeNull(); // still referenced
+  });
+});

--- a/test/openalex.fetch.test.ts
+++ b/test/openalex.fetch.test.ts
@@ -31,11 +31,7 @@ vi.stubGlobal("Zotero", mockZotero);
 // Import after the global is stubbed so module-level code sees it.
 import { getWorkById, resolveCanonicalId } from "../src/modules/openalex";
 
-function httpResponse(
-  status: number,
-  body: unknown = {},
-  headers: Record<string, string> = {},
-) {
+function httpResponse(status: number, body: unknown = {}, headers: Record<string, string> = {}) {
   return {
     status,
     responseText: JSON.stringify(body),
@@ -130,7 +126,9 @@ describe("error discrimination", () => {
   });
 
   it("returns the work on 200", async () => {
-    httpRequest.mockResolvedValue(httpResponse(200, { id: "https://openalex.org/W1", authorships: [] }));
+    httpRequest.mockResolvedValue(
+      httpResponse(200, { id: "https://openalex.org/W1", authorships: [] }),
+    );
     const work = await getWorkById("W1");
     expect(work?.id).toBe("https://openalex.org/W1");
   });

--- a/test/openalex.fetch.test.ts
+++ b/test/openalex.fetch.test.ts
@@ -1,0 +1,142 @@
+/**
+ * Tests for the U1 metered-OpenAlex fetch layer: API-key attachment,
+ * budget/auth error discrimination, canonical-id resolution, and key
+ * redaction. Exercises the real fetch path (getWorkById) against a mocked
+ * Zotero.HTTP so the retry/discriminator branches are covered end to end.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  OpenAlexBudgetError,
+  OpenAlexAuthError,
+  OpenAlexNetworkError,
+  normalizeError,
+  redactApiKey,
+} from "../src/modules/utils";
+
+let apiKeyPref = "";
+const httpRequest = vi.fn();
+
+const mockZotero = {
+  Prefs: {
+    get: vi.fn((pref: string) => {
+      if (pref === "extensions.zotero.citegeist.openAlexApiKey") return apiKeyPref;
+      return undefined;
+    }),
+  },
+  HTTP: { request: httpRequest },
+  debug: vi.fn(),
+};
+vi.stubGlobal("Zotero", mockZotero);
+
+// Import after the global is stubbed so module-level code sees it.
+import { getWorkById, resolveCanonicalId } from "../src/modules/openalex";
+
+function httpResponse(
+  status: number,
+  body: unknown = {},
+  headers: Record<string, string> = {},
+) {
+  return {
+    status,
+    responseText: JSON.stringify(body),
+    getResponseHeader: (name: string) => headers[name] ?? null,
+  };
+}
+
+beforeEach(() => {
+  apiKeyPref = "";
+  httpRequest.mockReset();
+  mockZotero.debug.mockReset();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("redactApiKey", () => {
+  it("redacts an api_key query value, preserving surrounding params", () => {
+    const url = "https://api.openalex.org/works/W1?api_key=sk-SECRET123&select=id";
+    const out = redactApiKey(url);
+    expect(out).not.toContain("sk-SECRET123");
+    expect(out).toContain("api_key=REDACTED");
+    expect(out).toContain("select=id");
+  });
+
+  it("is applied by normalizeError so a URL-bearing error never leaks the key", () => {
+    const e = new Error("request failed: https://api.openalex.org/works?api_key=LEAK&x=1");
+    const msg = normalizeError(e);
+    expect(msg).not.toContain("LEAK");
+    expect(msg).toContain("api_key=REDACTED");
+  });
+});
+
+describe("resolveCanonicalId", () => {
+  it("returns the short id from the response body (301-merge canonicalization)", () => {
+    expect(resolveCanonicalId({ id: "https://openalex.org/A999" })).toBe("A999");
+  });
+  it("returns null when the body has no id", () => {
+    expect(resolveCanonicalId({})).toBeNull();
+    expect(resolveCanonicalId(null)).toBeNull();
+  });
+});
+
+describe("api key attachment", () => {
+  it("attaches api_key to the request URL when the pref is set", async () => {
+    apiKeyPref = "sk-mykey";
+    httpRequest.mockResolvedValue(httpResponse(200, { id: "https://openalex.org/W1" }));
+    await getWorkById("W1");
+    const url = httpRequest.mock.calls[0][1] as string;
+    expect(url).toContain("api_key=sk-mykey");
+    expect(url).not.toContain("mailto");
+  });
+
+  it("issues an anonymous request (no api_key) when the pref is empty", async () => {
+    httpRequest.mockResolvedValue(httpResponse(200, { id: "https://openalex.org/W1" }));
+    await getWorkById("W1");
+    const url = httpRequest.mock.calls[0][1] as string;
+    expect(url).not.toContain("api_key");
+    expect(url).not.toContain("mailto");
+  });
+});
+
+describe("error discrimination", () => {
+  it("maps 401 to OpenAlexAuthError (no retry)", async () => {
+    httpRequest.mockResolvedValue(httpResponse(401));
+    await expect(getWorkById("W1")).rejects.toBeInstanceOf(OpenAlexAuthError);
+    expect(httpRequest).toHaveBeenCalledTimes(1);
+  });
+
+  it("maps 403 to OpenAlexAuthError (no retry)", async () => {
+    httpRequest.mockResolvedValue(httpResponse(403));
+    await expect(getWorkById("W1")).rejects.toBeInstanceOf(OpenAlexAuthError);
+    expect(httpRequest).toHaveBeenCalledTimes(1);
+  });
+
+  it("maps a 429 with X-RateLimit-Remaining: 0 to OpenAlexBudgetError (no retry)", async () => {
+    httpRequest.mockResolvedValue(httpResponse(429, {}, { "X-RateLimit-Remaining": "0" }));
+    await expect(getWorkById("W1")).rejects.toBeInstanceOf(OpenAlexBudgetError);
+    expect(httpRequest).toHaveBeenCalledTimes(1);
+  });
+
+  it("treats a 429 with remaining budget as transient and retries, then network-errors", async () => {
+    vi.useFakeTimers();
+    httpRequest.mockResolvedValue(httpResponse(429, {}, { "X-RateLimit-Remaining": "42" }));
+    const p = getWorkById("W1");
+    const assertion = expect(p).rejects.toBeInstanceOf(OpenAlexNetworkError);
+    await vi.runAllTimersAsync();
+    await assertion;
+    // initial attempt + 2 retries (OPENALEX_RETRY_DELAYS_MS has length 2)
+    expect(httpRequest).toHaveBeenCalledTimes(3);
+  });
+
+  it("returns the work on 200", async () => {
+    httpRequest.mockResolvedValue(httpResponse(200, { id: "https://openalex.org/W1", authorships: [] }));
+    const work = await getWorkById("W1");
+    expect(work?.id).toBe("https://openalex.org/W1");
+  });
+
+  it("returns null on 404", async () => {
+    httpRequest.mockResolvedValue(httpResponse(404));
+    expect(await getWorkById("W1")).toBeNull();
+  });
+});


### PR DESCRIPTION
## Phase A — OpenAlex metered-API key handling + author cache foundation

First slice of the [author-identity layer](docs/plans/2026-07-16-001-feat-author-identity-layer-plan.md). Shipped **first, as its own release**: U1 rewrites the shared `rateLimitedFetch`/`fetchJson` choke point every current OpenAlex call depends on, so the July-2026 metered-API correctness benefits (and de-risks) all existing functionality immediately — not just the upcoming author feature.

### Why now
OpenAlex went **metered/paid** in 2026 and **dropped the `mailto` polite pool**. Citegeist's client was still built on the obsolete mechanism (sending a dead `mailto`, no key support, no budget awareness). This PR makes the fetch layer correct for that world.

### U1 — metered fetch + API-key handling (`openalex.ts`, `utils.ts`, `constants.ts`)
- **Optional, opt-in API key** (`PREF_OPENALEX_API_KEY`). Anonymous requests still work at the lower daily budget; no default key is baked in.
- **Centralized key redaction** inside `normalizeError` — covers every path to `Zotero.debug`, including the retry-branch logs that bypass `logError`. A URL-bearing error can't leak the key.
- **Three-way error discrimination**: `OpenAlexBudgetError` (429 + `X-RateLimit-Remaining: 0`, no retry), `OpenAlexAuthError` (401/403), both distinct from `OpenAlexNetworkError`. A transient 429 still retries.
- `resolveCanonicalId()` for 301-merge canonicalization.
- Stops sending the now-dead `mailto` param + User-Agent tag.

### U2 — author cache sub-module (`cache/authors/*`, `cache/db.ts`, `cache/migration.ts`)
Storage foundation only (no UI, no network — those are Phases B/C):
- New `authors` + `item_authors` tables via additive `CREATE TABLE IF NOT EXISTS` (no schema-version gate; sidesteps the missing column-add path). Composite PKs reflect that Zotero item keys are unique only within a library.
- **Replicated** compile-time exhaustiveness + bind-shape gates per new row type.
- `cacheItemAuthors` — the piggyback identity write, with **curated-wins preservation** under the cache's shared per-`(library, item)` lock (now exported). Column-disjoint identity vs metric writes mean background resolution and profile-metric writes never clobber each other.
- `parseAuthorId` (`/^A\d{1,20}$/`) validation at the write boundary.
- Two-level orphan GC wired into `garbageCollectOrphans`; per-item cleanup in `deleteRow`.

### Tests
+19 (10 U1 fetch-layer, 9 U2 cache), full suite **388 pass**. typecheck / lint / prettier / build all green.

### Not in this PR
- Phase B: background resolution, backfill, Zotero-relation handoff (+ sync round-trip spike).
- Phase C: Scholar-style profile, curation UI, key-entry UX — each **front-end mockup-gated** before implementation.
- No behavioral author feature is user-visible yet; the tables populate in Phase B.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
