### PR TITLE
docs: unify next-step planning — retire fossil plans and duplicates

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,6 +35,7 @@ src/
   hooks.ts                      # Zotero lifecycle hooks
   modules/
     openalex.ts                 # OpenAlex API client — fetch, parse, rate limit, retry
+    openalexAuthors.ts          # OpenAlex Authors client — profiles + works (shares the rate limiter)
     cache/                      # SQLite-backed cache (v2.0.0+)
       db.ts                     # Connection, in-memory mirror, lifecycle (init/close)
       read.ts                   # Sync read API (mirror only)
@@ -43,10 +44,18 @@ src/
       types.ts                  # Public types + internal row shape + column list
       index.ts                  # Public surface (re-exports)
     citationService.ts          # Orchestration: fetch + cache + error handling
+    titleSearch.ts              # Metadata matching — title/year/author-scored fallback
+    authorProfile.ts            # Author profile + view-model layer (pure logic, no DOM)
     citationColumn.ts           # Sortable item-tree columns
     citationPane.ts             # Item-detail sidebar pane
     menu.ts                     # Right-click context menus
     utils.ts                    # Shared: escapeHTML, normalizeError, logError, safeHTML
+    diagnostics/                # CG-* error codes, guards, ring buffer, redacted report
+      codes.ts                  # Append-only CG-* code registry
+      guard.ts                  # guard/guardAsync/bindGuarded callback boundaries
+      record.ts                 # In-memory diagnostics ring buffer
+      report.ts                 # Copyable, redacted failure report
+      surface.ts                # Coded failure UI helpers
     citationNetwork/
       dialog.ts                 # Modal lifecycle (explicit DialogPhase state machine)
       results.ts                # Result rendering, pagination, infinite scroll
@@ -97,7 +106,7 @@ typings/                        # Zotero type declarations
 
 ## Release Process
 
-**Gate first.** Before tagging any `v*`, run `docs/RELEASE-CHECKLIST.md` — the manual host-verification gates (real-Zotero smoke on 7/8/9, diagnostics end-to-end, and the 2-device sync round-trip). The 519 tests mock Zotero, so the highest-risk surface (pane render, sidenav icon, sync integrity) has no automated coverage; auto-update hits 100% of users with no canary, so a bad tag is fleet-wide. The mechanical steps below only run once those gates pass.
+**Gate first.** Before tagging any `v*`, run `docs/RELEASE-CHECKLIST.md` — the manual host-verification gates (real-Zotero smoke on 7/8/9, diagnostics end-to-end, and the 2-device sync round-trip). The test suite mocks Zotero, so the highest-risk surface (pane render, sidenav icon, sync integrity) has no automated coverage; auto-update hits 100% of users with no canary, so a bad tag is fleet-wide. The mechanical steps below only run once those gates pass.
 
 Shipping to users requires a **tagged release**, not just a push to `main`:
 

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -2,43 +2,22 @@
 type: backlog
 title: Citegeist — backlog
 description: Curated longer-term enhancement ideas, each a candidate GitHub issue.
-timestamp: 2026-06-08
+timestamp: 2026-08-13
 tags: [citegeist, backlog, enhancements]
 ---
 
 # Citegeist Backlog
 
-A curated list of planned enhancements and ideas for Citegeist. Each item is a candidate for a GitHub issue — contributions are welcome on any of them. If you'd like to pick one up, open an issue (or comment on an existing one) to coordinate.
+A curated list of planned enhancements and ideas for Citegeist. Each item is a candidate for — or already tracked as — a GitHub issue (linked where one exists); contributions are welcome on any of them. If you'd like to pick one up, open an issue (or comment on an existing one) to coordinate.
 
-Items are grouped loosely by theme, not priority. See [CONTRIBUTING.md](CONTRIBUTING.md) before starting work.
-
----
-
-## Metadata-based matching for items without a recognized identifier
-
-**Labels:** `enhancement`, `high-impact`
-
-When no DOI, PMID, arXiv ID, or ISBN is present — or when the identifier returns "not found" on OpenAlex — Citegeist currently shows blank cells with no explanation. Many items in a typical Zotero library fall into this category: older conference papers, working papers, grey literature, items imported from imperfect bibliographic databases.
-
-**Proposed feature (fully specced in [DESIGN.md](DESIGN.md)):**
-
-- Fall back to a title + year OpenAlex search when direct lookup fails
-- Score the top candidate by word-level Dice similarity (title), year proximity, and author last-name overlap
-- Two confidence tiers: high (≥ 0.92, data shown with `~` prefix) and medium (0.72–0.92, suggestion card in pane)
-- Explicit Confirm / Not this paper controls — never auto-apply without researcher sign-off
-- On confirm: store `Citegeist.openAlexId` so future refreshes go direct, bypassing title search
-- Bonus: if the matched work has a DOI and the item doesn't, offer to add it with one click — permanently graduating the item out of the title-search pipeline
-
-**Why this matters for researchers:**
-Citation data for conference proceedings, working papers, and imported items from imperfect sources is currently invisible in Citegeist. Metadata matching closes this gap without requiring researchers to manually hunt for identifiers.
-
-See the full design rationale, confidence thresholds, UI states, and module structure in [DESIGN.md](DESIGN.md).
+Items are grouped loosely by theme, not priority. Shipped items leave this list (metadata-based title matching shipped as v1.2.0 — see `CHANGELOG.md`). See [CONTRIBUTING.md](CONTRIBUTING.md) before starting work.
 
 ---
 
 ## Expand journal rankings beyond business and management
 
 **Labels:** `enhancement`, `rankings`, `help wanted`
+**GitHub:** [#3](https://github.com/phdemotions/zotero-citegeist/issues/3)
 
 Citegeist currently bundles ~180 journals across business, management, economics, finance, IS, marketing, and psychology. Researchers in other fields have their own widely-used ranking lists.
 
@@ -68,6 +47,7 @@ If you use a ranking list in your field and would like to see it in Citegeist, p
 ## Export citation metrics for tenure packets and grant reports
 
 **Labels:** `enhancement`, `high-impact`
+**GitHub:** [#4](https://github.com/phdemotions/zotero-citegeist/issues/4)
 
 Researchers regularly need to compile citation metrics for tenure cases, promotion dossiers, annual reviews, and grant applications. Right now they have to manually copy numbers from Citegeist columns into a spreadsheet or document.
 
@@ -87,6 +67,7 @@ This would save researchers hours of manual work every review cycle.
 ## Collection-level analytics dashboard
 
 **Labels:** `enhancement`, `high-impact`
+**GitHub:** [#5](https://github.com/phdemotions/zotero-citegeist/issues/5)
 
 When doing a literature review or preparing a meta-analysis, researchers often want to understand the overall profile of a collection — not just individual papers.
 
@@ -106,6 +87,7 @@ This would help researchers characterize the quality and scope of their literatu
 ## Citation alerts — track papers gaining traction
 
 **Labels:** `enhancement`, `idea`
+**GitHub:** [#7](https://github.com/phdemotions/zotero-citegeist/issues/7)
 
 Researchers want to know when a paper in their library starts getting noticed. Currently, Citegeist shows a snapshot of the trend, but doesn't proactively notify you.
 
@@ -126,6 +108,7 @@ This would be especially useful for:
 ## Localization / i18n support
 
 **Labels:** `enhancement`, `help wanted`
+**GitHub:** [#8](https://github.com/phdemotions/zotero-citegeist/issues/8)
 
 Citegeist's UI strings (column headers, pane labels, button text, tooltips) are currently English-only. Zotero has a large international user base and supports localization through `.ftl` (Fluent) files.
 
@@ -170,4 +153,3 @@ v2 follow-up to the author identity layer (see the [author-identity-layer requir
 **Why deferred to v2:** it's a second major surface (its own view plus curation-at-scale) layered on the per-item pane profile and background identity resolution that ship in v1. The identity foundation should prove out before the aggregate view is worth building.
 
 **Depends on:** the `authors` / `item_authors` tables and background identity resolution delivered in v1.
-

--- a/docs/ISSUES.md
+++ b/docs/ISSUES.md
@@ -1,15 +1,16 @@
 ---
 type: issues
 title: Citegeist — open issues
-description: Open bugs and feature requests, tracked by priority.
-timestamp: 2026-06-10
+description: Open bugs, verification gates, and technical debt, tracked by priority.
+timestamp: 2026-08-13
 tags: [citegeist, issues]
 ---
 
 # Citegeist — Open Issues
 
-> **Last Updated:** 2026-08-02 (GitHub-issue reconcile: the right-click-menu bug (#67/#72) is confirmed STILL OPEN on the released v2.0.5 by 3 users — the internal tracker had it marked fixed; added BUG-MENU + BUG-QUIT (#78) + OKF drift #79. **v2.0.5 is the last released version**, 2026-07-09.)
-> **Previously:** 2026-07-20 (DIAG-001 + DEBT-010 closed: diagnostic codes and guards now cover the network dialog; settings pane swapped the dead `mailto` field for the `api_key` field). 2026-07-18 (author-identity layer **v3.0.0 merged to `main`** #75, untagged — see STATUS.md). Closed issues archived to `docs/archive/issues-closed.jsonl`.
+> **Last Updated:** 2026-08-13 (planning unification: FEAT-003/FEAT-004 moved out — feature requests live in `BACKLOG.md` + GitHub `enhancement` issues; this tracker carries bugs, verification gates, and debt only.)
+> **Previously:** 2026-08-02 (GitHub-issue reconcile: the right-click-menu bug (#67/#72) is confirmed STILL OPEN on the released v2.0.5 by 3 users — the internal tracker had it marked fixed; added BUG-MENU + BUG-QUIT (#78) + OKF drift #79. **v2.0.5 is the last released version**, 2026-07-09.)
+> 2026-07-20 (DIAG-001 + DEBT-010 closed: diagnostic codes and guards now cover the network dialog; settings pane swapped the dead `mailto` field for the `api_key` field). 2026-07-18 (author-identity layer **v3.0.0 merged to `main`** #75, untagged — see STATUS.md). Closed issues archived to `docs/archive/issues-closed.jsonl`.
 
 ---
 
@@ -20,7 +21,9 @@ tags: [citegeist, issues]
 | P0 (Blocker) | 0    |
 | P1 (High)    | 2    |
 | P2 (Medium)  | 2    |
-| P3 (Low)     | 9    |
+| P3 (Low)     | 7    |
+
+Feature requests are not tracked here — they live in [`BACKLOG.md`](BACKLOG.md) (curated detail) and GitHub `enhancement` issues (public intake).
 
 ---
 
@@ -71,18 +74,6 @@ _None currently._
 **Impact:** `npm run okf:drift` reports drift — pinned `ee67a5c` vs upstream `3fcbb9f` ([compare](https://github.com/GoogleCloudPlatform/knowledge-catalog/compare/ee67a5ca27044ebe7c38385f5b6cffc2305a9c1a...3fcbb9f828c2f23d109c855ee403c3a4c81f3a96)). Docs-only; no code impact.
 **Fix:** The deliberate monthly action — review the `okf/SPEC.md` diff, update conforming docs if needed, then re-pin in `~/developer/docs/standards/okf-adoption.md` (canonical) + `docs/STANDARDS.md`. Never auto-follow `main`.
 **Found:** 2026-07-25 (#79).
-
-### FEAT-003: Export citation metrics (CSV) for tenure packets
-
-**Impact:** Researchers manually copy numbers from Citegeist into spreadsheets
-**Fix:** Right-click collection → "Export Citation Report (Citegeist)" → CSV
-**Effort:** Medium
-
-### FEAT-004: Collection-level analytics dashboard
-
-**Impact:** No aggregate view of a collection's FWCI/percentile distribution
-**Fix:** Aggregate stats pane for selected collection (median FWCI, percentile distribution, top papers)
-**Effort:** Medium-High
 
 ### VERIFY-002: author-relation purge + sync-safety — 2-device check
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -2,13 +2,13 @@
 type: status
 title: Citegeist — project status
 description: Current project state, last session's work, and upcoming priorities.
-timestamp: 2026-06-15
+timestamp: 2026-08-13
 tags: [citegeist, status]
 ---
 
 # Citegeist — Status
 
-> **Last Updated:** 2026-08-02
+> **Last Updated:** 2026-08-13 (planning unification: the stale "Upcoming" table — five rows describing work already shipped between v1.1.0 and v3.0.0 — replaced with the sequenced plan below; feature requests consolidated into BACKLOG.md + GitHub; release history table completed through v2.0.5.)
 > **Phase:** **v3.0.0 staged on `main`, untagged.** Author identity (#75) and the diagnostics + Zotero-9 host-contract + pane-rebuild branch (#77, squash `277444b`, 2026-08-01) are both merged but **not tagged** — staged behind one future v3.0.0 release. #77 added a user-facing diagnostics layer (append-only `CG-*` error codes users can quote, guard/guardAsync boundaries on every Zotero callback, a redaction net, and metered-API budget/auth/response/network discrimination), fixed two silent-spinner-hang classes and closed the DB-write-leak class with a structural invariant test, and cleaned the review tail. Reviewed across 12 escalating adversarial rounds — converged with two consecutive full-panel rounds clean of P2+. **v2.0.5 is the last released version** (2026-07-09, a right-click-menu hotfix shipped isolated while v3.0.0 waited).
 > **Build:** typecheck (strict, no errors) · **519 tests** · lint (0 errors, 3 pre-existing `any` warnings) · format · OKF · build → `citegeist-3.0.0.xpi` (~107 KB), all green on **Node ≥22** (required by `.nvmrc`/CI — vitest 4's ESM config can't be `require()`d on Node 20; use `--no-file-parallelism` to distinguish real failures from the known parallel flakiness).
 
@@ -16,14 +16,14 @@ tags: [citegeist, status]
 
 ## Current State
 
-| Attribute        | Value                                                                                   |
-| ---------------- | --------------------------------------------------------------------------------------- |
-| **Version**      | 3.0.0 (#75 + #77 merged to `main`, untagged; **2.0.5 last released 2026-07-09**)        |
-| **Build Status** | Clean — 519 tests, typecheck/lint/format/OKF clean, XPI ~107 KB (Node ≥22)              |
-| **Open Issues**  | P0: 0, P1: 2, P2: 2, P3: 9 (see ISSUES.md; P1 = BUG-MENU #67/#72, BUG-QUIT #78)         |
-| **Stack**        | TypeScript 6, esbuild, vitest 4.1, ESLint 10, Zotero 7.0.10–9, SQLite, Node 22          |
-| **Data Source**  | OpenAlex (free, unauthenticated, CC0)                                                   |
-| **Distribution** | GitHub Releases → auto-update via `release` Release (self-maintaining); Zenodo-archived |
+| Attribute        | Value                                                                                                                |
+| ---------------- | -------------------------------------------------------------------------------------------------------------------- |
+| **Version**      | 3.0.0 (#75 + #77 merged to `main`, untagged; **2.0.5 last released 2026-07-09**)                                     |
+| **Build Status** | Clean — 519 tests, typecheck/lint/format/OKF clean, XPI ~107 KB (Node ≥22)                                           |
+| **Open Issues**  | P0: 0, P1: 2, P2: 2, P3: 7 (see ISSUES.md; P1 = BUG-MENU #67/#72, BUG-QUIT #78; feature requests live in BACKLOG.md) |
+| **Stack**        | TypeScript 6, esbuild, vitest 4.1, ESLint 10, Zotero 7.0.10–9, SQLite, Node 22                                       |
+| **Data Source**  | OpenAlex (free, unauthenticated, CC0)                                                                                |
+| **Distribution** | GitHub Releases → auto-update via `release` Release (self-maintaining); Zenodo-archived                              |
 
 ---
 
@@ -58,8 +58,6 @@ Also this session: closed issues moved to a machine-readable archive `docs/archi
 **Shipped 2026-06-08 (v2.0.2):** dark-mode citation-network tint fix — the dialog's sage-tint scale had a self-referential dark-theme arm (`light-dark(…, var(--cg-sage-tint-NN))`), invalid at computed-value time, so every dark-mode tint collapsed to transparent; now defined correctly. Design tokens (spacing, radii, type, motion, color ramps) consolidated into a canonical module `src/modules/ui/tokens.ts` that both the item pane and the network dialog consume; `docs/design-system/citegeist-primitives.html` added as the design reference (#45). Pane visually unchanged.
 
 **Shipped 2026-06-08 (v2.0.1):** batch/collection/library column repaint fix (#35), redesigned title-match confirm/discard card (#36), citation network browser improvements — new sort modes (first author, not-in-library) + hide-in-library filter + source-metadata header (#32), Zotero 8+ MenuManager with DOM fallback (#33), Zenodo DOI surfacing (#34), TS6/ESLint10/action-gh-release-v3 deps (#37). v2.0.0 (SQLite cache migration) shipped 2026-06-08 (#30).
-
-**Possible next:** show the candidate's _authors_ in the title-match card — deferred because it needs a new `pending_authors` cache column + a schema migration (the cache uses plain `CREATE TABLE IF NOT EXISTS`, no column-add path). See BACKLOG.
 
 ---
 
@@ -171,29 +169,31 @@ _None currently._
 
 ## Upcoming
 
-| Task                                                    | Priority | Notes                                                                                             |
-| ------------------------------------------------------- | -------- | ------------------------------------------------------------------------------------------------- |
-| Fix pane copy + menu.ts DOI guards (DEBT-001, DEBT-002) | P1       | Quick fixes; complete the identifier chain end-to-end                                             |
-| Upgrade bumpp→v10, esbuild→^0.28.0 (DEBT-003)           | P1       | 4 high-severity CVEs in bumpp; batch with esbuild update                                          |
-| Extract isBookType to utils.ts (DEBT-004)               | P2       | 5-min fix before book type list grows                                                             |
-| Migrate FetchResult to discriminated union (DEBT-005)   | P2       | Required before v1.2.0 suggestion branch                                                          |
-| Metadata-based matching (v1.2.0)                        | P2       | Title+year search fallback; Confirm/Dismiss UX; DOI population bonus — fully specced in DESIGN.md |
-| JOSS paper submission                                   | P2       | `paper/paper.md` exists; needs journal confirmation                                               |
-| Export citation metrics (CSV)                           | P3       | Right-click collection → export for tenure packets                                                |
-| Collection-level analytics                              | P3       | Aggregate FWCI/percentile for a folder                                                            |
+One sequenced plan. The detail lives in exactly one place per item — bugs, verification gates, and debt in `ISSUES.md`; feature ideas in `BACKLOG.md`; release gates in `RELEASE-CHECKLIST.md` — and this table only orders it.
 
-See `BACKLOG.md` for full details.
+| #   | Step                            | Detail lives in             | Notes                                                                                                                                                                                             |
+| --- | ------------------------------- | --------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1   | Run the v3.0.0 release gate     | `RELEASE-CHECKLIST.md`      | Real-Zotero smoke on 7/8/9 (VERIFY-001: pane composition + sidenav icon), diagnostics end-to-end, 2-device sync round-trip (VERIFY-002), BUG-MENU (#67/#72) + BUG-QUIT (#78) checked on a real Z9 |
+| 2   | Tag + ship v3.0.0               | `RELEASE-CHECKLIST.md` §5–6 | `CITATION.cff` + `CHANGELOG` date bump happen at tag time (deliberately held until the gate passes); post-release watch; close #22, and #67/#72/#78 once users confirm                            |
+| 3   | JOSS submission (JOSS-001)      | `ISSUES.md` P2              | Confirm target journal, final checks on `paper/paper.md`, submit                                                                                                                                  |
+| 4   | OKF pin review (OKF-DRIFT, #79) | `ISSUES.md` P3              | Deliberate monthly review + re-pin; never auto-follow upstream                                                                                                                                    |
+| 5   | Debt tail (DEBT-009, 011–014)   | `ISSUES.md` P3              | Batch as one single-concern cleanup PR after the release                                                                                                                                          |
+| 6   | Next feature from the backlog   | `BACKLOG.md`                | Leading candidates: export citation report (#4), collection analytics (#5), "My Authors" (v2 of the author-identity layer)                                                                        |
 
 ---
 
 ## Release History
 
-| Version | Date       | Summary                                                                      |
-| ------- | ---------- | ---------------------------------------------------------------------------- |
-| 2.0.2   | 2026-06-08 | Dark-mode dialog tint fix; canonical design-token module (both surfaces)     |
-| 2.0.1   | 2026-06-08 | Column repaint fix, redesigned title-match card, network browser sort/filter |
-| 2.0.0   | 2026-06-08 | SQLite-backed cache (migrated from Extra-field storage)                      |
-| 1.0.3   | 2026-04-09 | Non-DOI identifiers (PMID/arXiv/ISBN), rankings refresh (ABDC '25, AJG '24)  |
-| 1.0.2   | 2026-04-08 | Family design language, FWCI/percentile sort                                 |
-| 1.0.1   | 2026-04-08 | Quality pass: error handling, tooling, tests, docs                           |
-| 1.0.0   | 2026-04-05 | Initial public release                                                       |
+| Version     | Date                    | Summary                                                                                                        |
+| ----------- | ----------------------- | -------------------------------------------------------------------------------------------------------------- |
+| 2.0.5       | 2026-07-09              | Right-click-menu hotfix — MenuManager labels + registration lifecycle (#67)                                    |
+| 2.0.4       | 2026-06-10              | Shared-primitive unification (.cg-chip/.cg-card/.cg-banner); contrast fixes                                    |
+| 2.0.3       | 2026-06-10              | Settings shortcut, section icon fix, forced color-scheme theme fix, .cg-btn                                    |
+| 2.0.2       | 2026-06-08              | Dark-mode dialog tint fix; canonical design-token module (both surfaces)                                       |
+| 2.0.1       | 2026-06-08              | Column repaint fix, redesigned title-match card, network browser sort/filter                                   |
+| 2.0.0       | 2026-06-07              | SQLite-backed cache (migrated from Extra-field storage)                                                        |
+| 1.1.0–1.3.0 | 2026-04-09 – 2026-04-19 | Title-match fallback + confirm/dismiss (1.2.0), Zotero 9 compat (1.2.1), pane redesign (1.3.0) — see CHANGELOG |
+| 1.0.3       | 2026-04-09              | Non-DOI identifiers (PMID/arXiv/ISBN), rankings refresh (ABDC '25, AJG '24)                                    |
+| 1.0.2       | 2026-04-08              | Family design language, FWCI/percentile sort                                                                   |
+| 1.0.1       | 2026-04-08              | Quality pass: error handling, tooling, tests, docs                                                             |
+| 1.0.0       | 2026-04-05              | Initial public release                                                                                         |

--- a/docs/index.md
+++ b/docs/index.md
@@ -31,6 +31,8 @@ JOSS-exempt.
 ## Design system
 
 - [Pane composition language](design-system/pane-composition-language.md) — the composition rubric on top of the `--cg-*` tokens (one hero, near-cardless, 8pt rhythm); arbiter for pane layout
+- [Component primitives gallery](design-system/citegeist-primitives.html) — parity-tested HTML mirror of `ui/components.ts` (HTML reference; OKF-exempt)
+- [Citation-network toolbar mockup](mockups/citation-network-toolbar-ux.html) — UX mockup behind the shipped toolbar redesign (HTML reference; OKF-exempt)
 
 ## Plans
 
@@ -49,6 +51,9 @@ JOSS-exempt.
 
 - [Equal-weight metric tile grid](solutions/ui-bugs/misleading-citation-pane-metric-hierarchy-2026-04-19.md)
 - [Dev install: proxy file vs XPI](solutions/workflow-issues/zotero-plugin-dev-install-proxy-vs-xpi-2026-04-19.md)
+- [OpenAlex metered API handling](solutions/best-practices/openalex-metered-api-handling.md)
+- [Zotero 9 blank UI + sync break](solutions/integration-issues/zotero-9-plugin-blank-ui-and-sync-break.md)
+- [MenuManager blank labels + wedged right-click](solutions/ui-bugs/zotero-menumanager-blank-labels-and-wedged-right-click.md)
 
 ## Audits (2026-04-09, v1.1.0)
 


### PR DESCRIPTION
## Why

Audit found next-step planning scattered and partly fossilized: STATUS.md's "Upcoming" table carried five rows of work that shipped months ago (one row, "Metadata-based matching (v1.2.0)", shipped 2026-04-09 *as* v1.2.0), BACKLOG.md still proposed that same shipped feature as its top entry, and two features were tracked in three places at once (ISSUES.md + BACKLOG.md + GitHub).

## What

- **STATUS.md** — "Upcoming" is now one sequenced 6-step plan (release gate → tag v3.0.0 → JOSS → OKF pin → debt tail → next feature) that points at ISSUES/BACKLOG/RELEASE-CHECKLIST instead of duplicating them. Release-history table completed through 2.0.5; 2.0.0 date corrected to 2026-06-07 per CHANGELOG; stale "Possible next" fragment removed.
- **BACKLOG.md** — shipped metadata-matching entry removed (`titleSearch.ts` implements its spec verbatim, including the "Also add DOI to this item?" bonus at `citationPane.ts:807`); GitHub issue links added (#3/#4/#5/#7/#8).
- **ISSUES.md** — FEAT-003/FEAT-004 removed; features now live in BACKLOG.md + GitHub `enhancement` issues only. This tracker = bugs, verification gates, debt.
- **CLAUDE.md** — structure tree gains `diagnostics/`, `titleSearch.ts`, `openalexAuthors.ts`, `authorProfile.ts`; "519 tests" de-counted so the number can't drift.
- **docs/index.md** — catalog gains 3 uncatalogued solutions docs + 2 HTML references.

Docs-only; no code changes. `okf:check` + prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
