### PR TITLE
ci: bump actions/checkout 5→7 and actions/setup-node 6→7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,9 +16,9 @@ jobs:
         # and package.json `engines.node` is pinned to ">=22.0.0".
         node-version: [22]
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v7
         with:
           node-version: ${{ matrix.node-version }}
           cache: npm

--- a/.github/workflows/okf-watch.yml
+++ b/.github/workflows/okf-watch.yml
@@ -30,7 +30,7 @@ jobs:
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
       - name: Check OKF upstream drift
         id: drift

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,9 +12,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v7
         with:
           node-version: 22
           cache: npm


### PR DESCRIPTION
Replicates Dependabot #68 + #80 in one pass. Their individual PR CI runs are green with these versions — PR CI executes the PR's own workflow files, so those runs are the compatibility proof. Dependabot auto-closes #68/#80 once main carries the bumps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)